### PR TITLE
[codex] Dockerize CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+target/
+**/target/
+.pnpm-store/
+
+examples/vite/node_modules/
+examples/vite/dist/
+examples/vite/src/pkg/
+examples/vite/test-results/
+
+analyzer_wasm/bindings/
+
+.git/
+.github/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,8 +10,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "20"
-  PNPM_VERSION: "10.28.0"
+  CI_IMAGE: notion-formula-rs-ci:local
 
 jobs:
   ci:
@@ -20,48 +19,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ---- Rust toolchain ----
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build CI image
+        uses: docker/build-push-action@v6
         with:
-          targets: wasm32-unknown-unknown
+          context: .
+          file: Dockerfile.ci
+          tags: ${{ env.CI_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
-
-      - name: Install just
-        run: cargo install just --locked
-
-      # ---- Node + pnpm (pinned) ----
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: examples/vite/pnpm-lock.yaml
-
-      - name: Show tool versions
+      - name: Run checks and tests in CI image
         run: |
-          node -v
-          pnpm -v
-
-      - name: Install Vite deps
-        working-directory: examples/vite
-        run: pnpm i --frozen-lockfile
-
-      - name: Install Playwright browsers
-        working-directory: examples/vite
-        run: pnpm exec playwright install --with-deps
-
-      - name: Run tests via just
-        run: just test
+          docker run --rm --ipc=host \
+            -e CI=true \
+            -v "$PWD:/work" \
+            -w /work \
+            "$CI_IMAGE" \
+            just verify
 
   deploy:
     name: Deploy Pages
@@ -78,42 +56,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build CI image
+        uses: docker/build-push-action@v6
         with:
-          targets: wasm32-unknown-unknown
+          context: .
+          file: Dockerfile.ci
+          tags: ${{ env.CI_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
-
-      # ---- Node + pnpm (pinned) ----
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: examples/vite/pnpm-lock.yaml
-
-      - name: Install Vite deps
-        working-directory: examples/vite
-        run: pnpm i --frozen-lockfile
-
-      - name: Build WASM
-        working-directory: examples/vite
-        run: pnpm -s run wasm:build
-
-      - name: Build Vite (GitHub Pages base)
-        working-directory: examples/vite
-        env:
-          GITHUB_PAGES: "true"
-        run: pnpm -s run build
+      - name: Build Vite in CI image
+        run: |
+          docker run --rm \
+            -e GITHUB_PAGES=true \
+            -v "$PWD:/work" \
+            -w /work \
+            "$CI_IMAGE" \
+            just build
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 analyzer_wasm/bindings/
+.pnpm-store/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV PNPM_HOME=/pnpm
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/pnpm:/usr/local/cargo/bin:$PATH
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+WORKDIR /work
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --no-modify-path \
+    && rustup target add wasm32-unknown-unknown \
+    && rustup component add rustfmt clippy \
+    && cargo install wasm-pack --locked \
+    && cargo install just --locked \
+    && chmod -R a+rwX "$CARGO_HOME" "$RUSTUP_HOME"
+
+COPY examples/vite/package.json /tmp/vite-package.json
+
+RUN mkdir -p "$PNPM_HOME" /pnpm/store \
+    && npm install -g "$(node -p "require('/tmp/vite-package.json').packageManager")" \
+    && chmod -R a+rwX "$PNPM_HOME"
+
+ENV NPM_CONFIG_STORE_DIR=/pnpm/store
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Open the URL printed by Vite (usually `http://127.0.0.1:5173`).
 just test
 ```
 
+### 5) Run the full CI gate locally
+
+```bash
+# native
+just verify
+
+# inside the CI Docker image
+just docker-test
+```
+
 ## API Surface
 
 There is no end-user CLI compiler here. You normally integrate through Rust APIs or WASM exports.
@@ -281,13 +291,17 @@ cd examples/vite && pnpm -s run wasm:build && pnpm -s run test && pnpm -s run te
 
 ```bash
 # just
-just build     # build demo bundle (wasm build + install + vite build)
-just check    # cargo check + clippy + frontend checks
-just fmt      # rustfmt + frontend format
-just fix      # clippy --fix + frontend lint fixes
-just gen-ts   # export TS DTO types from analyzer_wasm
-just test     # repo test suite
+just deps      # fetch Rust crates + install frontend deps
+just build     # build demo bundle
+just check     # format check + Rust/frontend static checks
+just fix       # clippy/eslint fixes + Rust/frontend formatting
+just verify    # deps + check + test
+just docker-test # build CI image, then run verify inside it
+just gen-ts    # export TS DTO types from analyzer_wasm
+just test      # repo test suite
+just test-builtin_fn
 just test-analyzer
+just test-evaluator
 just test-ide
 just test-analyzer_wasm
 just test-analyzer-bless

--- a/analyzer/src/analysis/infer.rs
+++ b/analyzer/src/analysis/infer.rs
@@ -399,10 +399,10 @@ fn resolve_param_ref(
 ) -> String {
     for (i, param) in resolved_params.iter().enumerate() {
         if param.name == ref_name {
-            if let Some(arg) = args.get(i) {
-                if let ExprKind::Ident(sym) = &arg.kind {
-                    return sym.text.to_string();
-                }
+            if let Some(arg) = args.get(i)
+                && let ExprKind::Ident(sym) = &arg.kind
+            {
+                return sym.text.to_string();
             }
             break;
         }

--- a/analyzer/src/analysis/infer.rs
+++ b/analyzer/src/analysis/infer.rs
@@ -7,7 +7,7 @@ use crate::ast::{Expr, ExprKind, UnOp};
 use crate::{LitKind, NodeId};
 use std::collections::HashMap;
 
-use super::{normalize_union, Context, FunctionSig, GenericId, GenericParamKind, LambdaParam, Ty};
+use super::{Context, FunctionSig, GenericId, GenericParamKind, LambdaParam, Ty, normalize_union};
 
 /// Identifier for an expression node used as the key in [`TypeMap`].
 pub type ExprId = NodeId;

--- a/analyzer/src/lexer/mod.rs
+++ b/analyzer/src/lexer/mod.rs
@@ -302,57 +302,57 @@ pub fn lex(input: &str) -> LexOutput {
                     // Peek two chars ahead: need a digit after the dot.
                     let mut lookahead = iter.clone();
                     lookahead.next(); // consume '.'
-                    if let Some(&(_, c2)) = lookahead.peek() {
-                        if c2.is_ascii_digit() {
-                            iter.next(); // consume '.'
-                            end = dot_i + 1;
-                            while let Some(&(i, c2)) = iter.peek() {
-                                if c2.is_ascii_digit() {
-                                    iter.next();
-                                    end = i + c2.len_utf8();
-                                } else {
-                                    break;
-                                }
+                    if let Some(&(_, c2)) = lookahead.peek()
+                        && c2.is_ascii_digit()
+                    {
+                        iter.next(); // consume '.'
+                        end = dot_i + 1;
+                        while let Some(&(i, c2)) = iter.peek() {
+                            if c2.is_ascii_digit() {
+                                iter.next();
+                                end = i + c2.len_utf8();
+                            } else {
+                                break;
                             }
                         }
                     }
                 }
 
                 // Exponent part: 'e' or 'E', optional '+'/'-', then digits.
-                if let Some(&(_, ec)) = iter.peek() {
-                    if ec == 'e' || ec == 'E' {
-                        let mut lookahead = iter.clone();
-                        lookahead.next(); // consume 'e'/'E'
+                if let Some(&(_, ec)) = iter.peek()
+                    && (ec == 'e' || ec == 'E')
+                {
+                    let mut lookahead = iter.clone();
+                    lookahead.next(); // consume 'e'/'E'
 
-                        let mut has_digits = false;
-                        if let Some(&(_, sc)) = lookahead.peek() {
-                            if sc == '+' || sc == '-' {
-                                lookahead.next(); // consume sign
-                            }
-                            if let Some(&(_, dc)) = lookahead.peek() {
-                                has_digits = dc.is_ascii_digit();
-                            }
+                    let mut has_digits = false;
+                    if let Some(&(_, sc)) = lookahead.peek() {
+                        if sc == '+' || sc == '-' {
+                            lookahead.next(); // consume sign
                         }
+                        if let Some(&(_, dc)) = lookahead.peek() {
+                            has_digits = dc.is_ascii_digit();
+                        }
+                    }
 
-                        if has_digits {
-                            // Commit: consume e/E
-                            let (ei, _) = iter.next().unwrap();
-                            end = ei + 1;
-                            // Consume optional sign
-                            if let Some(&(si, sc)) = iter.peek() {
-                                if sc == '+' || sc == '-' {
-                                    iter.next();
-                                    end = si + 1;
-                                }
-                            }
-                            // Consume exponent digits
-                            while let Some(&(i, c2)) = iter.peek() {
-                                if c2.is_ascii_digit() {
-                                    iter.next();
-                                    end = i + c2.len_utf8();
-                                } else {
-                                    break;
-                                }
+                    if has_digits {
+                        // Commit: consume e/E
+                        let (ei, _) = iter.next().unwrap();
+                        end = ei + 1;
+                        // Consume optional sign
+                        if let Some(&(si, sc)) = iter.peek()
+                            && (sc == '+' || sc == '-')
+                        {
+                            iter.next();
+                            end = si + 1;
+                        }
+                        // Consume exponent digits
+                        while let Some(&(i, c2)) = iter.peek() {
+                            if c2.is_ascii_digit() {
+                                iter.next();
+                                end = i + c2.len_utf8();
+                            } else {
+                                break;
                             }
                         }
                     }

--- a/analyzer/src/lexer/mod.rs
+++ b/analyzer/src/lexer/mod.rs
@@ -4,8 +4,8 @@ mod token;
 
 pub use crate::span::{Span, Spanned};
 pub use token::{
-    tokens_in_span, CommentKind, Lit, LitKind, NodeId, Symbol, Token, TokenIdx, TokenKind,
-    TokenRange,
+    CommentKind, Lit, LitKind, NodeId, Symbol, Token, TokenIdx, TokenKind, TokenRange,
+    tokens_in_span,
 };
 
 pub struct LexOutput {

--- a/analyzer/src/parser/ast.rs
+++ b/analyzer/src/parser/ast.rs
@@ -1,6 +1,6 @@
 use crate::{
-    lexer::{Lit, NodeId, Span, Spanned, Symbol},
     Token, TokenKind,
+    lexer::{Lit, NodeId, Span, Spanned, Symbol},
 };
 
 pub enum AssocOp {

--- a/analyzer/src/parser/expr.rs
+++ b/analyzer/src/parser/expr.rs
@@ -943,16 +943,8 @@ impl DelimDepth {
         match kind {
             TokenKind::OpenParen => self.paren = self.paren.saturating_add(1),
             TokenKind::OpenBracket => self.bracket = self.bracket.saturating_add(1),
-            TokenKind::CloseParen => {
-                if self.paren > 0 {
-                    self.paren -= 1;
-                }
-            }
-            TokenKind::CloseBracket => {
-                if self.bracket > 0 {
-                    self.bracket -= 1;
-                }
-            }
+            TokenKind::CloseParen if self.paren > 0 => self.paren -= 1,
+            TokenKind::CloseBracket if self.bracket > 0 => self.bracket -= 1,
             _ => {}
         }
     }

--- a/analyzer/src/parser/expr.rs
+++ b/analyzer/src/parser/expr.rs
@@ -4,10 +4,10 @@
 //! `[start, end)`.
 
 use super::{ParseOutput, Parser};
+use crate::Token;
 use crate::ast::{AssocOp, Expr, ExprKind, NotKind, UnOp};
 use crate::diagnostics::{DiagnosticCode, Label, ParseDiagnostic};
 use crate::lexer::{Lit, LitKind, Span, Symbol, TokenKind};
-use crate::Token;
 
 impl<'a> Parser<'a> {
     /// Parser's entry point

--- a/analyzer/src/tests/analysis/test_generic_infer.rs
+++ b/analyzer/src/tests/analysis/test_generic_infer.rs
@@ -1,7 +1,7 @@
 use crate::analyze_syntax;
 use crate::semantic::{
-    infer_expr_with_map, Context, FunctionCategory, FunctionSig, GenericId, GenericParam,
-    GenericParamKind, ParamShape, ParamSig, Ty, TypeMap,
+    Context, FunctionCategory, FunctionSig, GenericId, GenericParam, GenericParamKind, ParamShape,
+    ParamSig, Ty, TypeMap, infer_expr_with_map,
 };
 
 fn p(name: &str, ty: Ty) -> ParamSig {

--- a/analyzer/src/tests/analysis/test_implicit_lambda.rs
+++ b/analyzer/src/tests/analysis/test_implicit_lambda.rs
@@ -1,6 +1,6 @@
 use crate::ast::ExprKind;
-use crate::semantic::{self, builtins_functions, Context, LambdaParam, Ty};
-use crate::{analyze_syntax, Span};
+use crate::semantic::{self, Context, LambdaParam, Ty, builtins_functions};
+use crate::{Span, analyze_syntax};
 
 fn builtins_ctx() -> Context {
     Context {

--- a/analyzer/src/tests/analysis/test_normalize_union.rs
+++ b/analyzer/src/tests/analysis/test_normalize_union.rs
@@ -1,4 +1,4 @@
-use crate::semantic::{normalize_union, Ty};
+use crate::semantic::{Ty, normalize_union};
 
 #[test]
 fn normalize_union_is_deterministic() {

--- a/analyzer/src/tests/analysis/test_semantic.rs
+++ b/analyzer/src/tests/analysis/test_semantic.rs
@@ -1,7 +1,7 @@
 use crate::semantic::{
     self, Context, FunctionCategory, FunctionSig, GenericId, ParamShape, ParamSig, Property, Ty,
 };
-use crate::{analyze_syntax, Span};
+use crate::{Span, analyze_syntax};
 
 fn p(name: &str, ty: Ty) -> ParamSig {
     ParamSig {

--- a/analyzer/src/tests/analysis/test_semantic_infer_builtins.rs
+++ b/analyzer/src/tests/analysis/test_semantic_infer_builtins.rs
@@ -1,5 +1,5 @@
-use crate::semantic::{self, builtins_functions, Context, Ty};
-use crate::{analyze_syntax, Span};
+use crate::semantic::{self, Context, Ty, builtins_functions};
+use crate::{Span, analyze_syntax};
 
 fn infer_ok(source: &str, ctx: &Context) -> Ty {
     let mut output = analyze_syntax(source);

--- a/analyzer/src/tests/analysis/test_sig_resolver.rs
+++ b/analyzer/src/tests/analysis/test_sig_resolver.rs
@@ -3,8 +3,8 @@
 //! - `flat()` uses a custom resolver for depth-sensitive return types.
 //! - `padStart`, `padEnd`, `formatNumber`, `splice` are new builtins added alongside the resolver.
 
-use crate::semantic::{self, builtins_functions, Context, Ty};
-use crate::{analyze_syntax, Span};
+use crate::semantic::{self, Context, Ty, builtins_functions};
+use crate::{Span, analyze_syntax};
 
 fn infer_ok(source: &str, ctx: &Context) -> Ty {
     let mut output = analyze_syntax(source);

--- a/analyzer/src/tests/lexer/test_lexer.rs
+++ b/analyzer/src/tests/lexer/test_lexer.rs
@@ -232,9 +232,11 @@ fn test_empty_input_eof_span() {
 fn test_unterminated_string_error() {
     let output = lex("\"abc");
     assert_eq!(output.diagnostics.len(), 1);
-    assert!(output.diagnostics[0]
-        .message
-        .contains("unterminated string"));
+    assert!(
+        output.diagnostics[0]
+            .message
+            .contains("unterminated string")
+    );
 }
 
 #[test]
@@ -264,9 +266,11 @@ fn test_unterminated_string_recovers_partial_tokens() {
     let output = lex(input);
     assert!(!output.tokens.is_empty());
     assert_eq!(output.diagnostics.len(), 1);
-    assert!(output.diagnostics[0]
-        .message
-        .contains("unterminated string"));
+    assert!(
+        output.diagnostics[0]
+            .message
+            .contains("unterminated string")
+    );
 
     let has_prop = output
         .tokens
@@ -444,9 +448,11 @@ fn test_string_unterminated_with_trailing_backslash() {
     let input = r#""abc\"#;
     let output = lex(input);
     assert_eq!(output.diagnostics.len(), 1);
-    assert!(output.diagnostics[0]
-        .message
-        .contains("unterminated string"));
+    assert!(
+        output.diagnostics[0]
+            .message
+            .contains("unterminated string")
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/analyzer/src/tests/parser/test_invariants.rs
+++ b/analyzer/src/tests/parser/test_invariants.rs
@@ -1,6 +1,6 @@
 use crate::ast::{Expr, ExprKind};
 use crate::lexer::lex;
-use crate::lexer::{tokens_in_span, Span, Token};
+use crate::lexer::{Span, Token, tokens_in_span};
 use crate::parser::{Parser, TokenCursor};
 
 fn assert_child_range(child: &Expr, parent: &Expr, tokens: &[Token]) {

--- a/analyzer_wasm/tests/analyze.rs
+++ b/analyzer_wasm/tests/analyze.rs
@@ -197,18 +197,26 @@ fn analyze_chinese_spans() {
 
 #[wasm_bindgen_test]
 fn analyze_emoji_spans_and_diagnostics() {
-    let source = "😀+1";
+    let source = "x😀";
     let result = analyze_value(source);
 
     let ident = &result.tokens[0];
     assert_eq!(ident.kind, "Ident");
     assert_eq!(ident.span.start, 0);
-    assert_eq!(ident.span.end, 2);
+    assert_eq!(ident.span.end, 1);
 
-    let plus = &result.tokens[1];
-    assert_eq!(plus.kind, "Plus");
-    assert_eq!(plus.span.start, 2);
-    assert_eq!(plus.span.end, 3);
+    let eof = &result.tokens[1];
+    assert_eq!(eof.kind, "Eof");
+    assert_eq!(eof.span.start, 3);
+    assert_eq!(eof.span.end, 3);
+
+    let diag = &result.diagnostics[0];
+    assert_eq!(diag.kind, "error");
+    assert!(diag.message.contains("unexpected char"));
+    assert_eq!(diag.span.start, 1);
+    assert_eq!(diag.span.end, 3);
+    assert_eq!(diag.line, 1);
+    assert_eq!(diag.col, 2);
 
     let error_source = "1 +";
     let error_result = analyze_value(error_source);

--- a/builtin_fn/src/parser/grammar.rs
+++ b/builtin_fn/src/parser/grammar.rs
@@ -60,7 +60,10 @@ enum ParsedTy {
     Date,
     Null,
     Any,
-    GenericRef { name: String, position: usize },
+    GenericRef {
+        name: String,
+        position: usize,
+    },
     List(Box<ParsedTy>),
     Union(Vec<ParsedTy>),
     Fn {

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,10 @@ From repo root:
 
 ```bash
 just test
+just verify
+just deps
 just check
-just fmt
+just fix
 just gen-ts
 
 cargo test

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -132,8 +132,9 @@ pnpm -C examples/vite test:e2e
 ## All-crate shortcuts
 
 ```bash
-just test       # all Rust tests
-just check      # cargo check
-just fmt         # cargo fmt
-cargo test       # all workspace tests
+just test        # repo test suite
+just verify      # deps + static checks + tests
+just docker-test # run verify inside the CI Docker image
+just check       # format check + Rust/frontend static checks
+cargo test       # workspace Rust tests
 ```

--- a/evaluator/src/kernels/arithmetic.rs
+++ b/evaluator/src/kernels/arithmetic.rs
@@ -96,8 +96,12 @@ pub(crate) fn eval_add(left: RowValue<'_>, right: RowValue<'_>) -> Result<Value,
     match (left, right) {
         (RowValue::Number(left), RowValue::Number(right)) => Ok(Value::Number(left + right)),
         (RowValue::Text(left), RowValue::Text(right)) => Ok(Value::Text(format!("{left}{right}"))),
-        (RowValue::Text(left), RowValue::Number(right)) => Ok(Value::Text(format!("{left}{right}"))),
-        (RowValue::Number(left), RowValue::Text(right)) => Ok(Value::Text(format!("{left}{right}"))),
+        (RowValue::Text(left), RowValue::Number(right)) => {
+            Ok(Value::Text(format!("{left}{right}")))
+        }
+        (RowValue::Number(left), RowValue::Text(right)) => {
+            Ok(Value::Text(format!("{left}{right}")))
+        }
         (RowValue::Text(left), RowValue::List(right)) => {
             Ok(Value::Text(format!("{left}{}", stringify_list(right))))
         }

--- a/evaluator/src/kernels/prepared.rs
+++ b/evaluator/src/kernels/prepared.rs
@@ -62,8 +62,8 @@ pub(crate) fn prepare_any_args<'a>(
 fn type_mismatch_prepare_block(mask: &Mask, left: &EvalBlock, right: &EvalBlock) -> EvalBlock {
     let len = mask.len();
     let mut errors = Vec::new();
-    for idx in 0..len {
-        if !mask[idx] || !left.ok[idx] || !right.ok[idx] {
+    for (idx, active) in mask.iter().copied().enumerate().take(len) {
+        if !active || !left.ok[idx] || !right.ok[idx] {
             continue;
         }
         if left.values.nulls[idx] || right.values.nulls[idx] {

--- a/evaluator/src/kernels/registry.rs
+++ b/evaluator/src/kernels/registry.rs
@@ -9,7 +9,8 @@ use super::prepared::{PreparedArgs, prepare_any_args, prepare_f64_args};
 
 pub(crate) type PrepareBinaryFn =
     for<'a> fn(&'a EvalBlock, &'a EvalBlock, &Mask) -> Result<PreparedArgs<'a>, EvalBlock>;
-pub(crate) type ExecBinaryFn = for<'a> fn(PreparedArgs<'a>, &Mask, Vec<(usize, EvalError)>) -> EvalBlock;
+pub(crate) type ExecBinaryFn =
+    for<'a> fn(PreparedArgs<'a>, &Mask, Vec<(usize, EvalError)>) -> EvalBlock;
 
 #[derive(Clone, Copy)]
 pub(crate) struct KernelEntry {

--- a/evaluator/src/planner/mod.rs
+++ b/evaluator/src/planner/mod.rs
@@ -1,4 +1,5 @@
 mod lower_lit;
+#[allow(clippy::module_inception)]
 mod planner;
 mod selectors;
 

--- a/evaluator/src/planner/planner.rs
+++ b/evaluator/src/planner/planner.rs
@@ -1,12 +1,12 @@
-use analyzer::analysis::{infer_expr_with_map, Context as SemaContext, Ty, TypeMap};
+use analyzer::analysis::{Context as SemaContext, Ty, TypeMap, infer_expr_with_map};
 use analyzer::ast::{BinOpKind, Expr, ExprKind};
 
 use crate::core::context::EvalContext;
 use crate::ir::nodes::{CastPlan, ExecNode, ExecPlan};
 
+use super::PlanError;
 use super::lower_lit::{lower_const_value, lower_lit};
 use super::selectors::select_binary_plan;
-use super::PlanError;
 
 #[derive(Debug, Default)]
 pub(crate) struct Planner;

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -41,7 +41,7 @@
   },
   "engines": {
     "node": ">=20",
-    "pnpm": "^10.28.0"
+    "pnpm": ">=10 <11"
   },
   "packageManager": "pnpm@10.28.0"
 }

--- a/ide/src/context.rs
+++ b/ide/src/context.rs
@@ -345,21 +345,9 @@ pub(crate) fn detect_call_context(tokens: &[Token], cursor: u32) -> Option<CallC
         match token.kind {
             TokenKind::OpenParen => paren_depth += 1,
             TokenKind::OpenBracket => bracket_depth += 1,
-            TokenKind::CloseParen => {
-                if paren_depth > 0 {
-                    paren_depth -= 1;
-                }
-            }
-            TokenKind::CloseBracket => {
-                if bracket_depth > 0 {
-                    bracket_depth -= 1;
-                }
-            }
-            TokenKind::Comma => {
-                if paren_depth == 0 && bracket_depth == 0 {
-                    arg_index += 1;
-                }
-            }
+            TokenKind::CloseParen if paren_depth > 0 => paren_depth -= 1,
+            TokenKind::CloseBracket if bracket_depth > 0 => bracket_depth -= 1,
+            TokenKind::Comma if paren_depth == 0 && bracket_depth == 0 => arg_index += 1,
             _ => {}
         }
     }

--- a/ide/src/signature/mod.rs
+++ b/ide/src/signature/mod.rs
@@ -191,7 +191,11 @@ fn infer_one_arg(expr_source: &str, ctx: &semantic::Context) -> Option<semantic:
 
     let mut parsed = analyzer::analyze_syntax(trimmed);
     let mut map = analyzer::TypeMap::default();
-    Some(analyzer::infer_expr_with_map(&mut parsed.expr, ctx, &mut map))
+    Some(analyzer::infer_expr_with_map(
+        &mut parsed.expr,
+        ctx,
+        &mut map,
+    ))
 }
 
 /// Splits the token stream after `lparen_idx` into per-argument byte spans,

--- a/ide/src/signature/mod.rs
+++ b/ide/src/signature/mod.rs
@@ -230,11 +230,7 @@ fn arg_spans(tokens: &[Token], lparen_idx: usize, source_len: u32) -> Vec<analyz
                     paren_depth -= 1;
                 }
             }
-            TokenKind::CloseBracket => {
-                if bracket_depth > 0 {
-                    bracket_depth -= 1;
-                }
-            }
+            TokenKind::CloseBracket if bracket_depth > 0 => bracket_depth -= 1,
             TokenKind::Comma if paren_depth == 0 && bracket_depth == 0 => {
                 spans.push(analyzer::Span {
                     start,

--- a/justfile
+++ b/justfile
@@ -1,38 +1,84 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
-build:
-  cd examples/vite && pnpm -s run wasm:build && pnpm -s i && pnpm -s run build
+ci-image := "notion-formula-rs-ci:local"
+
+# Dependencies
+
+deps: deps-rust deps-node
+
+deps-rust:
+  cargo fetch --locked
+  cargo fetch --locked --target wasm32-unknown-unknown
+
+deps-node:
+  pnpm -C examples/vite install --frozen-lockfile
+
+# CI
+
+verify: deps check test
+
+_docker-build-ci:
+  docker buildx build --load -f Dockerfile.ci -t {{ci-image}} .
+
+docker-test: _docker-build-ci
+  docker run --rm --ipc=host -e CI=true -v "$PWD:/work" -w /work {{ci-image}} just verify
+
+# Checks and fixes
 
 check:
-  cargo check && cargo clippy && cd examples/vite && pnpm -s run check
+  cargo fmt --all -- --check
+  cargo check
+  cargo clippy
+  pnpm -C examples/vite -s run check
 
 typecheck:
   cargo check
 
-wasm:
-  cd examples/vite && pnpm -s run wasm:build
-
 fix:
-  cargo clippy --fix --allow-dirty --allow-staged && cd examples/vite && pnpm -s run lint:fix
+  cargo clippy --fix --allow-dirty --allow-staged
+  cargo fmt --all
+  pnpm -C examples/vite -s run lint:fix
+  pnpm -C examples/vite -s run format:fix
 
-fmt:
-  cargo fmt --all && cd examples/vite && pnpm -s run format:fix
+# Build and dev
 
 gen-ts:
   cargo run -p analyzer_wasm --bin export_ts
 
-test: test-analyzer test-ide test-analyzer_wasm test-example-vite
+wasm:
+  pnpm -C examples/vite -s run wasm:build
 
-verify: test-analyzer test-ide test-analyzer_wasm
+build: deps-node wasm
+  pnpm -C examples/vite -s run build
+
+run-example-vite: deps-node wasm
+  pnpm -C examples/vite -s run dev
+
+clean:
+  cargo clean
+  cd examples/vite && rm -rf node_modules dist src/pkg test-results
+
+# Tests
+
+test: test-rust test-example-vite
+
+test-rust: test-builtin_fn test-analyzer test-evaluator test-ide test-analyzer_wasm
+
+test-builtin_fn:
+  cargo test -p builtin_fn
 
 test-analyzer:
   cargo test -p analyzer
+
+test-evaluator:
+  cargo test -p evaluator
 
 test-ide:
   cargo test -p ide
 
 test-analyzer_wasm:
   cargo test -p analyzer_wasm
+  wasm-pack test --node analyzer_wasm
 
 test-analyzer-bless:
   BLESS=1 cargo test -p analyzer
@@ -42,12 +88,6 @@ test-ide-bless:
 
 bless: test-analyzer-bless test-ide-bless
 
-test-example-vite:
-  cd examples/vite && pnpm -s run wasm:build && pnpm -s run test && pnpm -s run test:e2e
-
-run-example-vite:
-  cd examples/vite && pnpm -s run wasm:build && npm run dev
-
-clean:
-  cargo clean
-  cd examples/vite && rm -rf node_modules dist src/pkg test-results
+test-example-vite: deps-node wasm
+  pnpm -C examples/vite -s run test
+  pnpm -C examples/vite -s run test:e2e

--- a/justfile
+++ b/justfile
@@ -25,10 +25,14 @@ docker-test: _docker-build-ci
 
 # Checks and fixes
 
-check:
+check: check-rust check-example-vite
+
+check-rust:
   cargo fmt --all -- --check
   cargo check
   cargo clippy
+
+check-example-vite: wasm
   pnpm -C examples/vite -s run check
 
 typecheck:


### PR DESCRIPTION
## Summary

- Add a Playwright-based CI Docker image with Rust, wasm-pack, just, and pnpm installed from the Vite packageManager pin.
- Rework `justfile` recipes so local CI simulation and GitHub Actions share the same `just verify` path.
- Update the Pages workflow to build and run the CI image for checks, tests, and the Pages build.
- Refresh README/testing docs for the new `deps`, `check`, `fix`, `verify`, and `docker-test` entrypoints.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml"); puts "pages.yml ok"'`
- `just --dry-run verify && just --dry-run docker-test && just --dry-run build`
- `git diff --check`
- `rg '10\\.28\\.0|PNPM_VERSION' . .github -n`

Notes: a full final image rebuild was attempted locally but blocked on external apt/wasm-bindgen network stalls. The Docker image version parsing was verified earlier with `pnpm -v` returning `10.28.0`, and `wasm-pack test --node analyzer_wasm` passed in the container before the later Vite wasm build stalled on tool installation.