### PR TITLE
Implement builtin function runtime behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "analyzer"
 version = "0.1.0"
 dependencies = [
@@ -89,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +118,8 @@ version = "0.1.0"
 dependencies = [
  "analyzer",
  "builtin_fn",
+ "chrono",
+ "regex",
 ]
 
 [[package]]
@@ -230,6 +250,35 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustversion"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 - **Docs:** [Design docs](./docs/design/README.md)
 - **Status:**
   - Editor tooling (analyzer + completion/assists) is usable today.
-  - The prepared-input evaluator structure and generated builtin ABI are available;
-    builtin behavior is the next milestone.
+  - The prepared-input evaluator and supported builtin catalog execute synchronously.
 
 ## What is this?
 
@@ -48,18 +47,17 @@ Example:
 
 - `analyzer/`: parsing + diagnostics + semantic checks
 - `builtin_fn/`: compile-time builtin catalog + shared call-signature resolution
-- `evaluator/`: prepared-input synchronous runtime structure + generated builtin contracts
+- `evaluator/`: prepared-input synchronous runtime + generated builtin contracts and kernels
 - `ide/`: formatter + completion/signature help + edit ops
 - `analyzer_wasm/`: WASM/JS API + TypeScript DTOs
 - `examples/vite/`: CodeMirror demo + UI test coverage
 
 ## Current Limits
 
-- Non-builtin literals and operators execute through the synchronous evaluator, but builtin
-  implementation bodies are intentionally pending.
 - Language and type coverage are still expanding. Notion Formula compatibility is the default; extensions are additive and opt-in.
 - Unsupported builtin declarations remain documented in the catalog; types such as
-  `DateRange` and rich text are not modeled yet.
+  `DateRange` and rich text are not modeled yet, and person name/email data is not available
+  from runtime inputs.
 
 ## Prerequisites
 
@@ -358,7 +356,7 @@ just run-example-vite  # build wasm and start demo dev server
 | `analyzer/` | Core analyzer logic: lexer/parser/AST/diagnostics/semantic |
 | `ide/` | IDE/editor helpers: format/completion/help/edit-apply |
 | `analyzer_wasm/` | WASM boundary, UTF-16<->UTF-8 conversions, DTO serialization |
-| `evaluator/` | Prepared-input synchronous runtime and generated builtin ABI; builtin bodies pending |
+| `evaluator/` | Prepared-input synchronous runtime, generated builtin ABI, and builtin kernels |
 | `examples/vite/` | Browser demo (CodeMirror + WASM integration) |
 | `docs/` | Contracts, architecture docs, deep dives, and changelog guidance |
 

--- a/docs/changelogs/20260720-builtin-function-runtime.md
+++ b/docs/changelogs/20260720-builtin-function-runtime.md
@@ -1,0 +1,33 @@
+# 20260720-builtin-function-runtime
+
+- Type: Added
+- Component: evaluator
+
+## Summary
+
+All 83 supported builtin declarations now execute through the synchronous prepared-input
+evaluator. Value functions preserve independent null/error/mask state, while conditionals and
+list lambdas evaluate only their selected row masks. Generated typed arguments remain typed at
+the handwritten kernel boundary instead of being erased back to dynamic columns.
+
+## Compatibility notes
+
+- No public evaluator API or catalog syntax changed.
+- `now()` and `today()` use the frozen `BuiltinRuntimeContext`, and `id()` uses the current
+  `RowBatch` row IDs.
+- Catalog entries marked unsupported remain available to documentation and analysis but do not
+  have runtime dispatch obligations.
+
+## Tests
+
+- `cargo test -p evaluator`
+- `cargo test -p evaluator --release`
+- `cargo run -p builtin_fn --bin builtin_catalog -- --check`
+- Workspace and Docker verification are recorded in the pull request.
+
+## Links
+
+- [`docs/design/builtin-fn.md`](../design/builtin-fn.md)
+- [`docs/design/evaluator.md`](../design/evaluator.md)
+- [`docs/design/contracts.md`](../design/contracts.md)
+- [`evaluator/README.md`](../../evaluator/README.md)

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -102,11 +102,13 @@ Note: `cargo test -p analyzer_wasm` alone does not execute `wasm_bindgen_test` i
 
 - Locations: `evaluator/src/` unit tests and `evaluator/tests/` integration tests
 - Generated-contract coverage: deterministic full-catalog bindings, all five parameter
-  layouts, no generated lifetimes/dynamic context, and compile failures for a missing impl
-  or incorrect method signature
+  layouts, no generated lifetimes/dynamic context or dynamic Value-argument erasure, and compile
+  failures for a missing impl or incorrect method signature
 - Runtime-structure coverage: required-column manifests, all five `InputContractError`
   classes, independent mask/ok/validity, shared fan-out, unique storage recovery, debug
   contracts, and non-builtin operator execution
+- Runtime-behavior coverage: the bounded public matrix (`flat`, `concat`, `splice`, and `ifs`),
+  frozen runtime/row IDs, and focused cases for observed regressions
 
 Run:
 

--- a/evaluator/Cargo.toml
+++ b/evaluator/Cargo.toml
@@ -7,6 +7,8 @@ build = "build.rs"
 [dependencies]
 analyzer = { path = "../analyzer" }
 builtin_fn = { path = "../builtin_fn" }
+chrono = { version = "0.4.41", default-features = false, features = ["alloc", "std"] }
+regex = "1.11.1"
 
 [build-dependencies]
 builtin_fn = { path = "../builtin_fn" }

--- a/evaluator/README.md
+++ b/evaluator/README.md
@@ -44,10 +44,24 @@ Design rationale: [`docs/design/evaluator.md`](../docs/design/evaluator.md) and
 - Debug builds reuse resolved parameter and return types to validate active, successful,
   non-null rows at dispatch boundaries.
 
-All generated-trait implementations currently live in
-`src/builtins/implementations.rs` with intentional `todo!()` bodies. The generated structure
-and non-builtin literal/operator runtime are executable; calling a builtin is not supported
-until the behavior implementation change lands.
+All generated-trait implementations live in `src/builtins/implementations.rs`. Value kernels
+materialize typed arguments once and reuse shared family implementations; Controlled kernels
+retain typed plans so they can evaluate only the rows and branches selected by their masks.
+Unsupported catalog declarations do not generate evaluator obligations.
+
+## Builtin behavior
+
+- Value families cover general, text/regex, numeric, date, eager-list, and special functions.
+  Fixed ABI fields are read directly as typed scalars; top-level dynamic type switches are
+  confined to `AnyKind` fields (list elements remain `Value` by storage design). Null rows
+  propagate through `Validity` unless a function such as `empty()` explicitly interprets null.
+- `if()` and `ifs()` split masks before evaluating thunks. `let()` and list functions apply
+  generated lambda plans with typed binding contracts; unselected branches and later predicates
+  do not contribute errors.
+- `now()` and `today()` read the frozen `BuiltinRuntimeContext`; `id()` reads the matching
+  `RowId` from the current `RowBatch`.
+- `abs()` demonstrates the unique-storage in-place path while shared input columns keep their
+  row buffers and allocate a separate result.
 
 ## Layout
 
@@ -59,9 +73,10 @@ until the behavior implementation change lands.
 | `src/ir/` | owned arena plan and typed controlled-plan metadata |
 | `src/runtime/` | synchronous masked IR execution and non-builtin operators |
 | `src/builtins/` | generated contract inclusion, typed dispatch support, and impl obligations |
-| `src/kernels/` | reusable total, fallible, and null-aware compute helpers |
+| `src/kernels/` | Value-family kernels, Controlled mask/lambda kernels, and reusable helpers |
 | `tests/generated_contract.rs` | deterministic shape and compile-fail ABI contracts |
 | `tests/runtime_structure.rs` | public input, ownership, state, and preparation contracts |
+| `tests/builtin_behavior.rs` | bounded public behavior matrix across builtin families |
 
 ## Flow
 
@@ -86,14 +101,11 @@ borrow runtime state without leaking lifetimes into generated types.
 ```bash
 cargo test -p evaluator --test generated_contract
 cargo test -p evaluator --test runtime_structure
+cargo test -p evaluator --test builtin_behavior
 cargo test -p evaluator
 ```
 
 Tests cover all five parameter layouts, missing/wrong implementations, every
 `InputContractError`, required-column ordering, independent runtime states, shared fan-out,
-unique storage recovery, debug contracts, and preservation of non-builtin operators.
-
-## TODOs
-
-- Replace every intentional `todo!()` in `src/builtins/implementations.rs` with the bounded
-  Value and Controlled builtin behavior matrix.
+unique and in-place storage paths, debug contracts, Value family representatives, Controlled
+branch behavior, generated lambda-binding contracts, and preservation of non-builtin operators.

--- a/evaluator/build_support.rs
+++ b/evaluator/build_support.rs
@@ -233,10 +233,6 @@ fn emit_function_contract(out: &mut String, signature: &FunctionSig) {
     }
     writeln!(out, "}}").unwrap();
 
-    if mode == Mode::Value {
-        emit_into_dynamic(out, signature, mode, &args_name);
-    }
-
     match mode {
         Mode::Value => {
             writeln!(out, "pub(crate) trait {trait_name} {{").unwrap();
@@ -257,70 +253,6 @@ fn emit_function_contract(out: &mut String, signature: &FunctionSig) {
             writeln!(out, "}}\n").unwrap();
         }
     }
-}
-
-fn emit_into_dynamic(out: &mut String, signature: &FunctionSig, mode: Mode, args_name: &str) {
-    let dynamic = match mode {
-        Mode::Value => "DynamicValueArgs",
-        Mode::Controlled => "DynamicControlledArgs",
-    };
-    writeln!(out, "impl {args_name} {{").unwrap();
-    writeln!(out, "    #[allow(dead_code)]").unwrap();
-    writeln!(out, "    pub(crate) fn into_dynamic(self) -> {dynamic} {{").unwrap();
-    writeln!(out, "        {dynamic}::new(").unwrap();
-    writeln!(out, "            vec![").unwrap();
-    for param in &signature.params.head {
-        writeln!(
-            out,
-            "                {},",
-            erase_field_expr(
-                param,
-                &format!("self.{}", rust_field_name(&param.name)),
-                mode
-            )
-        )
-        .unwrap();
-    }
-    writeln!(out, "            ],").unwrap();
-    if signature.params.repeat.is_empty() {
-        writeln!(out, "            Vec::new(),").unwrap();
-    } else {
-        writeln!(
-            out,
-            "            self.repeat_groups.into_vec().into_iter().map(|group| vec!["
-        )
-        .unwrap();
-        for param in &signature.params.repeat {
-            writeln!(
-                out,
-                "                {},",
-                erase_field_expr(
-                    param,
-                    &format!("group.{}", rust_field_name(&param.name)),
-                    mode
-                )
-            )
-            .unwrap();
-        }
-        writeln!(out, "            ]).collect(),").unwrap();
-    }
-    writeln!(out, "            vec![").unwrap();
-    for param in &signature.params.tail {
-        writeln!(
-            out,
-            "                {},",
-            erase_field_expr(
-                param,
-                &format!("self.{}", rust_field_name(&param.name)),
-                mode
-            )
-        )
-        .unwrap();
-    }
-    writeln!(out, "            ],").unwrap();
-    writeln!(out, "        )").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "}}\n").unwrap();
 }
 
 fn emit_dispatch(out: &mut String, functions: &[&FunctionSig], selected_mode: Mode) {
@@ -528,22 +460,6 @@ fn field_type(param: &ParamSig, mode: Mode) -> String {
         format!("Option<{base}>")
     } else {
         base
-    }
-}
-
-fn erase_field_expr(param: &ParamSig, expression: &str, mode: Mode) -> String {
-    let erased = match mode {
-        Mode::Value => format!("{expression}.into_column()"),
-        Mode::Controlled => format!("{expression}.into_dynamic()"),
-    };
-    if param.optional {
-        let inner = match mode {
-            Mode::Value => "value.into_column()",
-            Mode::Controlled => "value.into_dynamic()",
-        };
-        format!("{expression}.map(|value| {inner})")
-    } else {
-        format!("::core::option::Option::Some({erased})")
     }
 }
 

--- a/evaluator/src/builtins/implementations.rs
+++ b/evaluator/src/builtins/implementations.rs
@@ -3,128 +3,514 @@ use crate::core::columns::{
 };
 use crate::core::context::BuiltinValueContext;
 use crate::core::types::Mask;
+use crate::kernels::controlled::{
+    eval_count, eval_every, eval_filter, eval_find, eval_find_index, eval_if, eval_ifs, eval_let,
+    eval_map, eval_some,
+};
+use crate::kernels::helpers::{eval_fallible_selected, eval_infallible_all_slots};
+use crate::kernels::value::{
+    Aggregate, DatePart, DateShift, ListPick, ListTransform, NumericBinary, NumericUnary,
+    RegexOperation, TextTransform, ceil_number, eval_abs, eval_aggregate, eval_concat,
+    eval_constant_number, eval_contains, eval_date_between, eval_date_part, eval_date_shift,
+    eval_empty, eval_equality, eval_flat, eval_format, eval_format_date, eval_format_number,
+    eval_from_timestamp, eval_id, eval_includes, eval_join, eval_length, eval_list_pick,
+    eval_list_transform, eval_now, eval_numeric_binary, eval_numeric_unary, eval_pad,
+    eval_parse_date, eval_regex, eval_repeat, eval_round, eval_slice, eval_splice, eval_split,
+    eval_substring, eval_text_transform, eval_timestamp, eval_to_number, eval_today, sqrt_number,
+};
 
 use super::contract::*;
 
-macro_rules! impl_value_kernel {
-    ($marker:ident, $kernel:ident, $args:ident, $return_kind:ty) => {
+macro_rules! impl_typed_value_kernel {
+    (
+        $marker:ident,
+        $kernel:ident,
+        $args_ty:ident,
+        $return_kind:ty;
+        $args:ident,
+        $context:ident,
+        $mask:ident => $body:expr
+    ) => {
         impl $kernel for $marker {
             fn eval<C: BuiltinValueContext>(
-                _args: $args,
-                _context: &C,
-                _mask: &Mask,
+                $args: $args_ty,
+                $context: &C,
+                $mask: &Mask,
             ) -> KernelResult<$return_kind> {
-                todo!("builtin behavior lands in PR3")
+                $body
             }
         }
     };
 }
 
-impl_value_kernel!(Empty, EmptyKernel, EmptyArgs, BooleanKind);
-impl_value_kernel!(Length, LengthKernel, LengthArgs, NumberKind);
-impl_value_kernel!(Format, FormatKernel, FormatArgs, TextKind);
-impl_value_kernel!(Equal, EqualKernel, EqualArgs, BooleanKind);
-impl_value_kernel!(Unequal, UnequalKernel, UnequalArgs, BooleanKind);
-
-impl_value_kernel!(Substring, SubstringKernel, SubstringArgs, TextKind);
-impl_value_kernel!(Contains, ContainsKernel, ContainsArgs, BooleanKind);
-impl_value_kernel!(Test, TestKernel, TestArgs, BooleanKind);
-impl_value_kernel!(Match, MatchKernel, MatchArgs, ListKind);
-impl_value_kernel!(Replace, ReplaceKernel, ReplaceArgs, TextKind);
-impl_value_kernel!(ReplaceAll, ReplaceAllKernel, ReplaceAllArgs, TextKind);
-impl_value_kernel!(Lower, LowerKernel, LowerArgs, TextKind);
-impl_value_kernel!(Upper, UpperKernel, UpperArgs, TextKind);
-impl_value_kernel!(Trim, TrimKernel, TrimArgs, TextKind);
-impl_value_kernel!(Repeat, RepeatKernel, RepeatArgs, TextKind);
-impl_value_kernel!(PadStart, PadStartKernel, PadStartArgs, TextKind);
-impl_value_kernel!(PadEnd, PadEndKernel, PadEndArgs, TextKind);
-impl_value_kernel!(Concat, ConcatKernel, ConcatArgs, ListKind);
-impl_value_kernel!(Join, JoinKernel, JoinArgs, TextKind);
-impl_value_kernel!(Split, SplitKernel, SplitArgs, ListKind);
-
-impl_value_kernel!(FormatNumber, FormatNumberKernel, FormatNumberArgs, TextKind);
-impl_value_kernel!(Add, AddKernel, AddArgs, NumberKind);
-impl_value_kernel!(Subtract, SubtractKernel, SubtractArgs, NumberKind);
-impl_value_kernel!(Multiply, MultiplyKernel, MultiplyArgs, NumberKind);
-impl_value_kernel!(Mod, ModKernel, ModArgs, NumberKind);
-impl_value_kernel!(Pow, PowKernel, PowArgs, NumberKind);
-impl_value_kernel!(Divide, DivideKernel, DivideArgs, NumberKind);
-impl_value_kernel!(Min, MinKernel, MinArgs, NumberKind);
-impl_value_kernel!(Max, MaxKernel, MaxArgs, NumberKind);
-impl_value_kernel!(Sum, SumKernel, SumArgs, NumberKind);
-impl_value_kernel!(Median, MedianKernel, MedianArgs, NumberKind);
-impl_value_kernel!(Mean, MeanKernel, MeanArgs, NumberKind);
-impl_value_kernel!(Abs, AbsKernel, AbsArgs, NumberKind);
-impl_value_kernel!(Round, RoundKernel, RoundArgs, NumberKind);
-impl_value_kernel!(Ceil, CeilKernel, CeilArgs, NumberKind);
-impl_value_kernel!(Floor, FloorKernel, FloorArgs, NumberKind);
-impl_value_kernel!(Sqrt, SqrtKernel, SqrtArgs, NumberKind);
-impl_value_kernel!(Cbrt, CbrtKernel, CbrtArgs, NumberKind);
-impl_value_kernel!(Exp, ExpKernel, ExpArgs, NumberKind);
-impl_value_kernel!(Ln, LnKernel, LnArgs, NumberKind);
-impl_value_kernel!(Log10, Log10Kernel, Log10Args, NumberKind);
-impl_value_kernel!(Log2, Log2Kernel, Log2Args, NumberKind);
-impl_value_kernel!(Sign, SignKernel, SignArgs, NumberKind);
-impl_value_kernel!(Pi, PiKernel, PiArgs, NumberKind);
-impl_value_kernel!(E, EKernel, EArgs, NumberKind);
-impl_value_kernel!(ToNumber, ToNumberKernel, ToNumberArgs, NumberKind);
-
-impl_value_kernel!(Now, NowKernel, NowArgs, DateKind);
-impl_value_kernel!(Today, TodayKernel, TodayArgs, DateKind);
-impl_value_kernel!(Minute, MinuteKernel, MinuteArgs, NumberKind);
-impl_value_kernel!(Hour, HourKernel, HourArgs, NumberKind);
-impl_value_kernel!(Day, DayKernel, DayArgs, NumberKind);
-impl_value_kernel!(Date, DateKernel, DateArgs, NumberKind);
-impl_value_kernel!(Week, WeekKernel, WeekArgs, NumberKind);
-impl_value_kernel!(Month, MonthKernel, MonthArgs, NumberKind);
-impl_value_kernel!(Year, YearKernel, YearArgs, NumberKind);
-impl_value_kernel!(DateAdd, DateAddKernel, DateAddArgs, DateKind);
-impl_value_kernel!(DateSubtract, DateSubtractKernel, DateSubtractArgs, DateKind);
-impl_value_kernel!(DateBetween, DateBetweenKernel, DateBetweenArgs, NumberKind);
-impl_value_kernel!(Timestamp, TimestampKernel, TimestampArgs, NumberKind);
-impl_value_kernel!(
-    FromTimestamp,
-    FromTimestampKernel,
-    FromTimestampArgs,
-    DateKind
+impl_typed_value_kernel!(
+    Empty, EmptyKernel, EmptyArgs, BooleanKind;
+    args, _context, mask => eval_empty(args.value, mask)
 );
-impl_value_kernel!(FormatDate, FormatDateKernel, FormatDateArgs, TextKind);
-impl_value_kernel!(ParseDate, ParseDateKernel, ParseDateArgs, DateKind);
+impl_typed_value_kernel!(
+    Length, LengthKernel, LengthArgs, NumberKind;
+    args, _context, mask => eval_length(args.value, mask)
+);
+impl_typed_value_kernel!(
+    Format, FormatKernel, FormatArgs, TextKind;
+    args, context, mask => eval_format(args.value, context, mask)
+);
+impl_typed_value_kernel!(
+    Equal, EqualKernel, EqualArgs, BooleanKind;
+    args, _context, mask => eval_equality(args.a, args.b, false, mask)
+);
+impl_typed_value_kernel!(
+    Unequal, UnequalKernel, UnequalArgs, BooleanKind;
+    args, _context, mask => eval_equality(args.a, args.b, true, mask)
+);
 
-impl_value_kernel!(At, AtKernel, AtArgs, AnyKind);
-impl_value_kernel!(First, FirstKernel, FirstArgs, AnyKind);
-impl_value_kernel!(Last, LastKernel, LastArgs, AnyKind);
-impl_value_kernel!(Slice, SliceKernel, SliceArgs, ListKind);
-impl_value_kernel!(Splice, SpliceKernel, SpliceArgs, ListKind);
-impl_value_kernel!(Sort, SortKernel, SortArgs, ListKind);
-impl_value_kernel!(Reverse, ReverseKernel, ReverseArgs, ListKind);
-impl_value_kernel!(Unique, UniqueKernel, UniqueArgs, ListKind);
-impl_value_kernel!(Includes, IncludesKernel, IncludesArgs, BooleanKind);
-impl_value_kernel!(Flat, FlatKernel, FlatArgs, ListKind);
+impl_typed_value_kernel!(
+    Substring, SubstringKernel, SubstringArgs, TextKind;
+    args, _context, mask => eval_substring(args.text, args.start, args.end, mask)
+);
+impl_typed_value_kernel!(
+    Contains, ContainsKernel, ContainsArgs, BooleanKind;
+    args, _context, mask => eval_contains(args.text, args.search, mask)
+);
+impl_typed_value_kernel!(
+    Test, TestKernel, TestArgs, BooleanKind;
+    args, _context, mask => eval_regex::<BooleanKind>(
+        args.text, args.regex, None, RegexOperation::Test, mask
+    )
+);
+impl_typed_value_kernel!(
+    Match, MatchKernel, MatchArgs, ListKind;
+    args, _context, mask => eval_regex::<ListKind>(
+        args.text, args.regex, None, RegexOperation::Match, mask
+    )
+);
+impl_typed_value_kernel!(
+    Replace, ReplaceKernel, ReplaceArgs, TextKind;
+    args, _context, mask => eval_regex::<TextKind>(
+        args.text,
+        args.regex,
+        Option::Some(args.replacement),
+        RegexOperation::ReplaceOne,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    ReplaceAll, ReplaceAllKernel, ReplaceAllArgs, TextKind;
+    args, _context, mask => eval_regex::<TextKind>(
+        args.text,
+        args.regex,
+        Option::Some(args.replacement),
+        RegexOperation::ReplaceAll,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    Lower, LowerKernel, LowerArgs, TextKind;
+    args, _context, mask => eval_text_transform(args.text, TextTransform::Lower, mask)
+);
+impl_typed_value_kernel!(
+    Upper, UpperKernel, UpperArgs, TextKind;
+    args, _context, mask => eval_text_transform(args.text, TextTransform::Upper, mask)
+);
+impl_typed_value_kernel!(
+    Trim, TrimKernel, TrimArgs, TextKind;
+    args, _context, mask => eval_text_transform(args.text, TextTransform::Trim, mask)
+);
+impl_typed_value_kernel!(
+    Repeat, RepeatKernel, RepeatArgs, TextKind;
+    args, _context, mask => eval_repeat(args.text, args.times, mask)
+);
+impl_typed_value_kernel!(
+    PadStart, PadStartKernel, PadStartArgs, TextKind;
+    args, _context, mask => eval_pad(args.text, args.length, args.pad, true, mask)
+);
+impl_typed_value_kernel!(
+    PadEnd, PadEndKernel, PadEndArgs, TextKind;
+    args, _context, mask => eval_pad(args.text, args.length, args.pad, false, mask)
+);
+impl_typed_value_kernel!(
+    Concat, ConcatKernel, ConcatArgs, ListKind;
+    args, _context, mask => eval_concat(args, mask)
+);
+impl_typed_value_kernel!(
+    Join, JoinKernel, JoinArgs, TextKind;
+    args, _context, mask => eval_join(args.list, args.separator, mask)
+);
+impl_typed_value_kernel!(
+    Split, SplitKernel, SplitArgs, ListKind;
+    args, _context, mask => eval_split(args.text, args.separator, mask)
+);
 
-impl_value_kernel!(Id, IdKernel, IdArgs, TextKind);
+impl_typed_value_kernel!(
+    FormatNumber, FormatNumberKernel, FormatNumberArgs, TextKind;
+    args, _context, mask => eval_format_number(args.value, args.format, args.precision, mask)
+);
+impl_typed_value_kernel!(
+    Add, AddKernel, AddArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.a, args.b, NumericBinary::Add, mask)
+);
+impl_typed_value_kernel!(
+    Subtract, SubtractKernel, SubtractArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.a, args.b, NumericBinary::Subtract, mask)
+);
+impl_typed_value_kernel!(
+    Multiply, MultiplyKernel, MultiplyArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.a, args.b, NumericBinary::Multiply, mask)
+);
+impl_typed_value_kernel!(
+    Mod, ModKernel, ModArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.a, args.b, NumericBinary::Mod, mask)
+);
+impl_typed_value_kernel!(
+    Pow, PowKernel, PowArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.base, args.exp, NumericBinary::Pow, mask)
+);
+impl_typed_value_kernel!(
+    Divide, DivideKernel, DivideArgs, NumberKind;
+    args, _context, mask => eval_numeric_binary(args.a, args.b, NumericBinary::Divide, mask)
+);
+impl_typed_value_kernel!(
+    Min, MinKernel, MinArgs, NumberKind;
+    args, _context, mask => eval_aggregate(
+        args.repeat_groups
+            .into_vec()
+            .into_iter()
+            .map(|group| group.values)
+            .collect(),
+        Aggregate::Min,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    Max, MaxKernel, MaxArgs, NumberKind;
+    args, _context, mask => eval_aggregate(
+        args.repeat_groups
+            .into_vec()
+            .into_iter()
+            .map(|group| group.values)
+            .collect(),
+        Aggregate::Max,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    Sum, SumKernel, SumArgs, NumberKind;
+    args, _context, mask => eval_aggregate(
+        args.repeat_groups
+            .into_vec()
+            .into_iter()
+            .map(|group| group.values)
+            .collect(),
+        Aggregate::Sum,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    Median, MedianKernel, MedianArgs, NumberKind;
+    args, _context, mask => eval_aggregate(
+        args.repeat_groups
+            .into_vec()
+            .into_iter()
+            .map(|group| group.values)
+            .collect(),
+        Aggregate::Median,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    Mean, MeanKernel, MeanArgs, NumberKind;
+    args, _context, mask => eval_aggregate(
+        args.repeat_groups
+            .into_vec()
+            .into_iter()
+            .map(|group| group.values)
+            .collect(),
+        Aggregate::Mean,
+        mask,
+    )
+);
 
-macro_rules! impl_controlled_kernel {
-    ($marker:ident, $kernel:ident, $plans:ident, $return_kind:ty) => {
-        impl $kernel for $marker {
-            fn eval<C: super::BuiltinEvalContext>(
-                _context: &mut C,
-                _args: $plans,
-                _mask: &Mask,
-            ) -> KernelResult<$return_kind> {
-                todo!("builtin behavior lands in PR3")
-            }
-        }
-    };
+impl_typed_value_kernel!(
+    Abs, AbsKernel, AbsArgs, NumberKind;
+    args, _context, mask => eval_abs(args.value, mask)
+);
+impl_typed_value_kernel!(
+    Round, RoundKernel, RoundArgs, NumberKind;
+    args, _context, mask => eval_round(args.value, args.places, mask)
+);
+impl_typed_value_kernel!(
+    Ceil, CeilKernel, CeilArgs, NumberKind;
+    args, _context, mask => {
+        eval_infallible_all_slots(&args.value, mask, |value| ceil_number(*value))
+    }
+);
+impl_typed_value_kernel!(
+    Floor, FloorKernel, FloorArgs, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Floor, mask)
+);
+impl_typed_value_kernel!(
+    Sqrt, SqrtKernel, SqrtArgs, NumberKind;
+    args, _context, mask => {
+        eval_fallible_selected(&args.value, mask, |value| sqrt_number(*value))
+    }
+);
+impl_typed_value_kernel!(
+    Cbrt, CbrtKernel, CbrtArgs, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Cbrt, mask)
+);
+impl_typed_value_kernel!(
+    Exp, ExpKernel, ExpArgs, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Exp, mask)
+);
+impl_typed_value_kernel!(
+    Ln, LnKernel, LnArgs, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Ln, mask)
+);
+impl_typed_value_kernel!(
+    Log10, Log10Kernel, Log10Args, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Log10, mask)
+);
+impl_typed_value_kernel!(
+    Log2, Log2Kernel, Log2Args, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Log2, mask)
+);
+impl_typed_value_kernel!(
+    Sign, SignKernel, SignArgs, NumberKind;
+    args, _context, mask => eval_numeric_unary(args.value, NumericUnary::Sign, mask)
+);
+impl_typed_value_kernel!(
+    Pi, PiKernel, PiArgs, NumberKind;
+    _args, _context, mask => eval_constant_number(std::f64::consts::PI, mask)
+);
+impl_typed_value_kernel!(
+    E, EKernel, EArgs, NumberKind;
+    _args, _context, mask => eval_constant_number(std::f64::consts::E, mask)
+);
+impl_typed_value_kernel!(
+    ToNumber, ToNumberKernel, ToNumberArgs, NumberKind;
+    args, _context, mask => eval_to_number(args.value, mask)
+);
+
+impl_typed_value_kernel!(
+    Now, NowKernel, NowArgs, DateKind;
+    _args, context, mask => eval_now(context, mask)
+);
+impl_typed_value_kernel!(
+    Today, TodayKernel, TodayArgs, DateKind;
+    _args, context, mask => eval_today(context, mask)
+);
+impl_typed_value_kernel!(
+    Minute, MinuteKernel, MinuteArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Minute, context, mask)
+);
+impl_typed_value_kernel!(
+    Hour, HourKernel, HourArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Hour, context, mask)
+);
+impl_typed_value_kernel!(
+    Day, DayKernel, DayArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Day, context, mask)
+);
+impl_typed_value_kernel!(
+    Date, DateKernel, DateArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Date, context, mask)
+);
+impl_typed_value_kernel!(
+    Week, WeekKernel, WeekArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Week, context, mask)
+);
+impl_typed_value_kernel!(
+    Month, MonthKernel, MonthArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Month, context, mask)
+);
+impl_typed_value_kernel!(
+    Year, YearKernel, YearArgs, NumberKind;
+    args, context, mask => eval_date_part(args.date, DatePart::Year, context, mask)
+);
+impl_typed_value_kernel!(
+    DateAdd, DateAddKernel, DateAddArgs, DateKind;
+    args, context, mask => eval_date_shift(
+        args.date,
+        args.amount,
+        args.unit,
+        DateShift::Add,
+        context,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    DateSubtract, DateSubtractKernel, DateSubtractArgs, DateKind;
+    args, context, mask => eval_date_shift(
+        args.date,
+        args.amount,
+        args.unit,
+        DateShift::Subtract,
+        context,
+        mask,
+    )
+);
+impl_typed_value_kernel!(
+    DateBetween, DateBetweenKernel, DateBetweenArgs, NumberKind;
+    args, context, mask => eval_date_between(args.a, args.b, args.unit, context, mask)
+);
+impl_typed_value_kernel!(
+    Timestamp, TimestampKernel, TimestampArgs, NumberKind;
+    args, _context, mask => eval_timestamp(args.date, mask)
+);
+impl_typed_value_kernel!(
+    FromTimestamp, FromTimestampKernel, FromTimestampArgs, DateKind;
+    args, _context, mask => eval_from_timestamp(args.timestamp, mask)
+);
+impl_typed_value_kernel!(
+    FormatDate, FormatDateKernel, FormatDateArgs, TextKind;
+    args, context, mask => eval_format_date(args.date, args.format, context, mask)
+);
+impl_typed_value_kernel!(
+    ParseDate, ParseDateKernel, ParseDateArgs, DateKind;
+    args, context, mask => eval_parse_date(args.text, context, mask)
+);
+
+impl_typed_value_kernel!(
+    At, AtKernel, AtArgs, AnyKind;
+    args, _context, mask => eval_list_pick(args.list, Option::Some(args.index), ListPick::At, mask)
+);
+impl_typed_value_kernel!(
+    First, FirstKernel, FirstArgs, AnyKind;
+    args, _context, mask => eval_list_pick(args.list, None, ListPick::First, mask)
+);
+impl_typed_value_kernel!(
+    Last, LastKernel, LastArgs, AnyKind;
+    args, _context, mask => eval_list_pick(args.list, None, ListPick::Last, mask)
+);
+impl_typed_value_kernel!(
+    Slice, SliceKernel, SliceArgs, ListKind;
+    args, _context, mask => eval_slice(args.list, args.start, args.end, mask)
+);
+impl_typed_value_kernel!(
+    Splice, SpliceKernel, SpliceArgs, ListKind;
+    args, _context, mask => eval_splice(args, mask)
+);
+impl_typed_value_kernel!(
+    Sort, SortKernel, SortArgs, ListKind;
+    args, _context, mask => eval_list_transform(args.list, ListTransform::Sort, mask)
+);
+impl_typed_value_kernel!(
+    Reverse, ReverseKernel, ReverseArgs, ListKind;
+    args, _context, mask => eval_list_transform(args.list, ListTransform::Reverse, mask)
+);
+impl_typed_value_kernel!(
+    Unique, UniqueKernel, UniqueArgs, ListKind;
+    args, _context, mask => eval_list_transform(args.list, ListTransform::Unique, mask)
+);
+impl_typed_value_kernel!(
+    Includes, IncludesKernel, IncludesArgs, BooleanKind;
+    args, _context, mask => eval_includes(args.list, args.value, mask)
+);
+impl_typed_value_kernel!(
+    Flat, FlatKernel, FlatArgs, ListKind;
+    args, _context, mask => eval_flat(args.list, mask)
+);
+impl_typed_value_kernel!(
+    Id, IdKernel, IdArgs, TextKind;
+    _args, context, mask => eval_id(context, mask)
+);
+
+impl IfKernel for If {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: IfPlans,
+        mask: &Mask,
+    ) -> KernelResult<AnyKind> {
+        eval_if(context, args, mask)
+    }
 }
 
-impl_controlled_kernel!(If, IfKernel, IfPlans, AnyKind);
-impl_controlled_kernel!(Ifs, IfsKernel, IfsPlans, AnyKind);
-impl_controlled_kernel!(Let, LetKernel, LetPlans, AnyKind);
-impl_controlled_kernel!(Map, MapKernel, MapPlans, ListKind);
-impl_controlled_kernel!(Filter, FilterKernel, FilterPlans, ListKind);
-impl_controlled_kernel!(Find, FindKernel, FindPlans, AnyKind);
-impl_controlled_kernel!(FindIndex, FindIndexKernel, FindIndexPlans, NumberKind);
-impl_controlled_kernel!(Some, SomeKernel, SomePlans, BooleanKind);
-impl_controlled_kernel!(Every, EveryKernel, EveryPlans, BooleanKind);
-impl_controlled_kernel!(Count, CountKernel, CountPlans, NumberKind);
+impl IfsKernel for Ifs {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: IfsPlans,
+        mask: &Mask,
+    ) -> KernelResult<AnyKind> {
+        eval_ifs(context, args, mask)
+    }
+}
+
+impl LetKernel for Let {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: LetPlans,
+        mask: &Mask,
+    ) -> KernelResult<AnyKind> {
+        eval_let(context, args, mask)
+    }
+}
+
+impl MapKernel for Map {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: MapPlans,
+        mask: &Mask,
+    ) -> KernelResult<ListKind> {
+        eval_map(context, args, mask)
+    }
+}
+
+impl FilterKernel for Filter {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: FilterPlans,
+        mask: &Mask,
+    ) -> KernelResult<ListKind> {
+        eval_filter(context, args, mask)
+    }
+}
+
+impl FindKernel for Find {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: FindPlans,
+        mask: &Mask,
+    ) -> KernelResult<AnyKind> {
+        eval_find(context, args, mask)
+    }
+}
+
+impl FindIndexKernel for FindIndex {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: FindIndexPlans,
+        mask: &Mask,
+    ) -> KernelResult<NumberKind> {
+        eval_find_index(context, args, mask)
+    }
+}
+
+impl SomeKernel for Some {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: SomePlans,
+        mask: &Mask,
+    ) -> KernelResult<BooleanKind> {
+        eval_some(context, args, mask)
+    }
+}
+
+impl EveryKernel for Every {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: EveryPlans,
+        mask: &Mask,
+    ) -> KernelResult<BooleanKind> {
+        eval_every(context, args, mask)
+    }
+}
+
+impl CountKernel for Count {
+    fn eval<C: super::BuiltinEvalContext>(
+        context: &mut C,
+        args: CountPlans,
+        mask: &Mask,
+    ) -> KernelResult<NumberKind> {
+        eval_count(context, args, mask)
+    }
+}

--- a/evaluator/src/builtins/mod.rs
+++ b/evaluator/src/builtins/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod contract {
     use crate::ir::DebugCallContract;
 
     use super::support::{
-        BinderHandle, BuiltinEvalContext, DynamicValueArgs, LambdaPlan, PreparedArgumentError,
+        BinderHandle, BuiltinEvalContext, LambdaPlan, PreparedArgumentError,
         PreparedControlledArguments, PreparedValueArguments, RepeatGroups, ThunkPlan, ValuePlan,
         finish_controlled_result, signature_for_key,
     };

--- a/evaluator/src/builtins/support.rs
+++ b/evaluator/src/builtins/support.rs
@@ -228,44 +228,6 @@ pub(crate) struct ConditionSplit {
     pub(crate) when_false: Mask,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct DynamicValueArgs {
-    head: Box<[Option<Column>]>,
-    repeat_groups: Box<[Box<[Option<Column>]>]>,
-    #[allow(dead_code)]
-    tail: Box<[Option<Column>]>,
-}
-
-impl DynamicValueArgs {
-    pub(crate) fn new(
-        head: Vec<Option<Column>>,
-        repeat_groups: Vec<Vec<Option<Column>>>,
-        tail: Vec<Option<Column>>,
-    ) -> Self {
-        Self {
-            head: head.into_boxed_slice(),
-            repeat_groups: repeat_groups
-                .into_iter()
-                .map(Vec::into_boxed_slice)
-                .collect(),
-            tail: tail.into_boxed_slice(),
-        }
-    }
-
-    pub(crate) fn head(&self, index: usize) -> Option<&Column> {
-        self.head.get(index).and_then(Option::as_ref)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn tail(&self, index: usize) -> Option<&Column> {
-        self.tail.get(index).and_then(Option::as_ref)
-    }
-
-    pub(crate) fn repeat_groups(&self) -> &[Box<[Option<Column>]>] {
-        &self.repeat_groups
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PreparedArgumentError {
     Missing {

--- a/evaluator/src/kernels/controlled.rs
+++ b/evaluator/src/kernels/controlled.rs
@@ -1,0 +1,451 @@
+use crate::builtins::contract::{
+    CountPlans, EveryPlans, FilterPlans, FindIndexPlans, FindPlans, IfPlans, IfsPlans, LetPlans,
+    MapPlans, SomePlans,
+};
+use crate::builtins::{
+    BuiltinEvalContext, BuiltinKey, LambdaBindings, LambdaPlan, RowOutcome, ValuePlan,
+    block_into_kernel, rows_to_kernel,
+};
+use crate::core::columns::{
+    AnyKind, BooleanKind, Column, ColumnKind, KernelColumn, KernelResult, ListKind, Validity,
+};
+use crate::core::errors::EvalError;
+use crate::core::types::{EvalBlock, Mask, Value};
+
+pub(crate) fn eval_if<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: IfPlans,
+    mask: &Mask,
+) -> KernelResult<AnyKind> {
+    let condition = context.eval(args.condition, mask);
+    let split = context.split_mask(&condition, mask);
+    let then_block = context
+        .eval_thunk(args.then, &split.when_true)
+        .into_eval_block();
+    let else_block = context
+        .eval_thunk(args.else_, &split.when_false)
+        .into_eval_block();
+    merge_branches(
+        condition.into_eval_block(),
+        then_block,
+        else_block,
+        mask,
+        &split.when_true,
+    )
+}
+
+pub(crate) fn eval_ifs<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: IfsPlans,
+    mask: &Mask,
+) -> KernelResult<AnyKind> {
+    let mut remaining = mask.clone();
+    let mut outcomes = vec![RowOutcome::Inactive; mask.len()];
+    let mut errors = Vec::new();
+
+    for group in args.repeat_groups.into_vec() {
+        if !remaining.any() {
+            break;
+        }
+        let condition = context.eval(group.condition, &remaining);
+        errors.extend(condition.errors.iter().cloned());
+        for (row, outcome) in outcomes.iter_mut().enumerate() {
+            if remaining[row] && !condition.ok[row] {
+                *outcome = RowOutcome::Failed;
+            }
+        }
+        let split = context.split_mask(&condition, &remaining);
+        let value = context
+            .eval_thunk(group.value, &split.when_true)
+            .into_eval_block();
+        errors.extend(value.errors.iter().cloned());
+        for (row, outcome) in outcomes.iter_mut().enumerate() {
+            if split.when_true[row] {
+                *outcome = block_outcome(&value, row);
+            }
+        }
+        remaining = split.when_false;
+    }
+
+    if remaining.any() {
+        let else_block = context.eval_thunk(args.else_, &remaining).into_eval_block();
+        errors.extend(else_block.errors.iter().cloned());
+        for (row, outcome) in outcomes.iter_mut().enumerate() {
+            if remaining[row] {
+                *outcome = block_outcome(&else_block, row);
+            }
+        }
+    }
+
+    let mut result = rows_to_kernel::<AnyKind>(outcomes, mask);
+    result.errors.extend(errors);
+    result
+}
+
+pub(crate) fn eval_let<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: LetPlans,
+    mask: &Mask,
+) -> KernelResult<AnyKind> {
+    if args.ident.owner() != context.plan_owner() {
+        return block_into_kernel(EvalBlock::fail_mask(mask, EvalError::InvalidArgument), mask);
+    }
+    let name = args.ident.name().to_string();
+    let value = context.eval(args.value, mask).into_eval_block();
+    let body_mask = mask.and(&value.ok);
+    let body = context
+        .apply_lambda(
+            args.body,
+            LambdaBindings::new(vec![(name, value.column.clone())]),
+            &body_mask,
+        )
+        .into_eval_block();
+    let rows = (0..mask.len())
+        .map(|row| {
+            if !mask[row] {
+                RowOutcome::Inactive
+            } else if !value.ok[row] {
+                RowOutcome::Failed
+            } else {
+                block_outcome(&body, row)
+            }
+        })
+        .collect();
+    let mut result = rows_to_kernel::<AnyKind>(rows, mask);
+    result.errors.extend(value.errors);
+    result.errors.extend(body.errors);
+    result
+}
+
+pub(crate) fn eval_map<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: MapPlans,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    eval_map_impl(context, args.list, args.mapper, mask)
+}
+
+pub(crate) fn eval_filter<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: FilterPlans,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    eval_predicate_list(context, BuiltinKey::Filter, args.list, args.predicate, mask)
+}
+
+pub(crate) fn eval_find<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: FindPlans,
+    mask: &Mask,
+) -> KernelResult<AnyKind> {
+    eval_predicate_list(context, BuiltinKey::Find, args.list, args.predicate, mask)
+}
+
+pub(crate) fn eval_find_index<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: FindIndexPlans,
+    mask: &Mask,
+) -> KernelResult<crate::core::columns::NumberKind> {
+    eval_predicate_list(
+        context,
+        BuiltinKey::FindIndex,
+        args.list,
+        args.predicate,
+        mask,
+    )
+}
+
+pub(crate) fn eval_some<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: SomePlans,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_predicate_list(context, BuiltinKey::Some, args.list, args.predicate, mask)
+}
+
+pub(crate) fn eval_every<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: EveryPlans,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_predicate_list(context, BuiltinKey::Every, args.list, args.predicate, mask)
+}
+
+pub(crate) fn eval_count<C: BuiltinEvalContext>(
+    context: &mut C,
+    args: CountPlans,
+    mask: &Mask,
+) -> KernelResult<crate::core::columns::NumberKind> {
+    eval_predicate_list(context, BuiltinKey::Count, args.list, args.predicate, mask)
+}
+
+fn eval_map_impl<C: BuiltinEvalContext>(
+    context: &mut C,
+    list_plan: ValuePlan<ListKind>,
+    mapper: LambdaPlan<AnyKind>,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    let list = context.eval(list_plan, mask).into_eval_block();
+    let (lists, mut outcomes, mut active) = initialize_lists(&list, mask, ListInitial::EmptyList);
+    let mut errors = list.errors.clone();
+    let max_len = lists
+        .iter()
+        .filter_map(Option::as_ref)
+        .map(Vec::len)
+        .max()
+        .unwrap_or(0);
+    let parameter = mapper
+        .parameters()
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "current".to_string());
+
+    for index in 0..max_len {
+        let element_mask = element_mask(&lists, &active, index, mask.len());
+        if !element_mask.any() {
+            continue;
+        }
+        let binding = element_binding(&lists, index, &element_mask);
+        let mapped = context
+            .apply_lambda(
+                mapper.clone(),
+                LambdaBindings::new(vec![(parameter.clone(), binding)]),
+                &element_mask,
+            )
+            .into_eval_block();
+        errors.extend(mapped.errors.iter().cloned());
+        for row in 0..mask.len() {
+            if !element_mask[row] {
+                continue;
+            }
+            if !mapped.ok[row] {
+                active.set(row, false);
+                outcomes[row] = RowOutcome::Failed;
+            } else if let Some(value) = mapped.column.row_value(row) {
+                if let RowOutcome::Value(Value::List(output)) = &mut outcomes[row] {
+                    output.push(value);
+                }
+            } else {
+                active.set(row, false);
+                outcomes[row] = RowOutcome::Null;
+            }
+        }
+    }
+
+    let mut result = rows_to_kernel::<ListKind>(outcomes, mask);
+    result.errors.extend(errors);
+    result
+}
+
+fn eval_predicate_list<C: BuiltinEvalContext, K: ColumnKind>(
+    context: &mut C,
+    key: BuiltinKey,
+    list_plan: ValuePlan<ListKind>,
+    predicate: LambdaPlan<BooleanKind>,
+    mask: &Mask,
+) -> KernelResult<K> {
+    let list = context.eval(list_plan, mask).into_eval_block();
+    let initial = match key {
+        BuiltinKey::Filter => ListInitial::EmptyList,
+        BuiltinKey::Find => ListInitial::Null,
+        BuiltinKey::FindIndex => ListInitial::Number(-1.0),
+        BuiltinKey::Some => ListInitial::Bool(false),
+        BuiltinKey::Every => ListInitial::Bool(true),
+        BuiltinKey::Count => ListInitial::Number(0.0),
+        _ => ListInitial::Null,
+    };
+    let (lists, mut outcomes, mut active) = initialize_lists(&list, mask, initial);
+    let mut errors = list.errors.clone();
+    let max_len = lists
+        .iter()
+        .filter_map(Option::as_ref)
+        .map(Vec::len)
+        .max()
+        .unwrap_or(0);
+    let parameter = predicate
+        .parameters()
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "current".to_string());
+
+    for index in 0..max_len {
+        let element_mask = element_mask(&lists, &active, index, mask.len());
+        if !element_mask.any() {
+            continue;
+        }
+        let binding = element_binding(&lists, index, &element_mask);
+        let tested = context
+            .apply_lambda(
+                predicate.clone(),
+                LambdaBindings::new(vec![(parameter.clone(), binding)]),
+                &element_mask,
+            )
+            .into_eval_block();
+        errors.extend(tested.errors.iter().cloned());
+
+        for row in 0..mask.len() {
+            if !element_mask[row] {
+                continue;
+            }
+            if !tested.ok[row] {
+                active.set(row, false);
+                outcomes[row] = RowOutcome::Failed;
+                continue;
+            }
+            let passed = matches!(tested.column.row_value(row), Some(Value::Bool(true)));
+            let element = lists[row]
+                .as_ref()
+                .and_then(|list| list.get(index))
+                .cloned()
+                .expect("element mask only selects existing elements");
+            match key {
+                BuiltinKey::Filter if passed => {
+                    if let RowOutcome::Value(Value::List(output)) = &mut outcomes[row] {
+                        output.push(element);
+                    }
+                }
+                BuiltinKey::Find if passed => {
+                    outcomes[row] = RowOutcome::Value(element);
+                    active.set(row, false);
+                }
+                BuiltinKey::FindIndex if passed => {
+                    outcomes[row] = RowOutcome::Value(Value::Number(index as f64));
+                    active.set(row, false);
+                }
+                BuiltinKey::Some if passed => {
+                    outcomes[row] = RowOutcome::Value(Value::Bool(true));
+                    active.set(row, false);
+                }
+                BuiltinKey::Every if !passed => {
+                    outcomes[row] = RowOutcome::Value(Value::Bool(false));
+                    active.set(row, false);
+                }
+                BuiltinKey::Count if passed => {
+                    if let RowOutcome::Value(Value::Number(count)) = &mut outcomes[row] {
+                        *count += 1.0;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut result = rows_to_kernel::<K>(outcomes, mask);
+    result.errors.extend(errors);
+    result
+}
+
+#[derive(Clone, Copy)]
+enum ListInitial {
+    EmptyList,
+    Null,
+    Number(f64),
+    Bool(bool),
+}
+
+fn initialize_lists(
+    list: &EvalBlock,
+    mask: &Mask,
+    initial: ListInitial,
+) -> (Vec<Option<Vec<Value>>>, Vec<RowOutcome>, Mask) {
+    let mut lists = Vec::with_capacity(mask.len());
+    let mut outcomes = Vec::with_capacity(mask.len());
+    let mut active = Mask::none(mask.len());
+    for row in 0..mask.len() {
+        if !mask[row] {
+            lists.push(None);
+            outcomes.push(RowOutcome::Inactive);
+            continue;
+        }
+        if !list.ok[row] {
+            lists.push(None);
+            outcomes.push(RowOutcome::Failed);
+            continue;
+        }
+        match list.column.row_value(row) {
+            Some(Value::List(values)) => {
+                lists.push(Some(values));
+                outcomes.push(match initial {
+                    ListInitial::EmptyList => RowOutcome::Value(Value::List(Vec::new())),
+                    ListInitial::Null => RowOutcome::Null,
+                    ListInitial::Number(value) => RowOutcome::Value(Value::Number(value)),
+                    ListInitial::Bool(value) => RowOutcome::Value(Value::Bool(value)),
+                });
+                active.set(row, true);
+            }
+            None => {
+                lists.push(None);
+                outcomes.push(RowOutcome::Null);
+            }
+            Some(_) => {
+                lists.push(None);
+                outcomes.push(RowOutcome::Error(EvalError::TypeMismatch));
+            }
+        }
+    }
+    (lists, outcomes, active)
+}
+
+fn element_mask(lists: &[Option<Vec<Value>>], active: &Mask, index: usize, len: usize) -> Mask {
+    (0..len)
+        .map(|row| active[row] && lists[row].as_ref().is_some_and(|list| index < list.len()))
+        .collect()
+}
+
+fn element_binding(lists: &[Option<Vec<Value>>], index: usize, mask: &Mask) -> Column {
+    let values = (0..mask.len())
+        .map(|row| {
+            if mask[row] {
+                lists[row]
+                    .as_ref()
+                    .and_then(|list| list.get(index))
+                    .cloned()
+                    .expect("element mask only selects existing elements")
+            } else {
+                Value::Number(0.0)
+            }
+        })
+        .collect();
+    Column::Any(KernelColumn::from_values(values, Validity::AllValid))
+}
+
+fn merge_branches(
+    condition: EvalBlock,
+    then_block: EvalBlock,
+    else_block: EvalBlock,
+    mask: &Mask,
+    then_mask: &Mask,
+) -> KernelResult<AnyKind> {
+    let rows = (0..mask.len())
+        .map(|row| {
+            if !mask[row] {
+                return RowOutcome::Inactive;
+            }
+            if !condition.ok[row] {
+                return RowOutcome::Failed;
+            }
+            if then_mask[row] {
+                block_outcome(&then_block, row)
+            } else {
+                block_outcome(&else_block, row)
+            }
+        })
+        .collect();
+    let mut result = rows_to_kernel::<AnyKind>(rows, mask);
+    result.errors.extend(condition.errors);
+    result.errors.extend(then_block.errors);
+    result.errors.extend(else_block.errors);
+    result
+}
+
+fn block_outcome(block: &EvalBlock, row: usize) -> RowOutcome {
+    if !block.ok[row] {
+        RowOutcome::Failed
+    } else {
+        block
+            .column
+            .row_value(row)
+            .map(RowOutcome::Value)
+            .unwrap_or(RowOutcome::Null)
+    }
+}

--- a/evaluator/src/kernels/mod.rs
+++ b/evaluator/src/kernels/mod.rs
@@ -1,1 +1,3 @@
+pub(crate) mod controlled;
 pub(crate) mod helpers;
+pub(crate) mod value;

--- a/evaluator/src/kernels/value.rs
+++ b/evaluator/src/kernels/value.rs
@@ -1,0 +1,1255 @@
+use std::cmp::Ordering;
+
+use chrono::{Datelike, FixedOffset, Months, NaiveDate, TimeZone, Timelike, Utc};
+use regex::Regex;
+
+use crate::builtins::contract::{ConcatArgs, SpliceArgs};
+use crate::core::columns::{
+    AnyKind, BooleanKind, ColumnKind, DateKind, KernelColumn, KernelResult, ListKind, NumberKind,
+    TextKind, Validity,
+};
+use crate::core::context::BuiltinValueContext;
+use crate::core::errors::EvalError;
+use crate::core::types::{Mask, Value};
+use crate::runtime::operators::stringify_value;
+
+#[derive(Clone, Debug)]
+enum TypedRow<T> {
+    Value(T),
+    Null,
+    Inactive,
+    Error(EvalError),
+}
+
+fn eval_rows<K: ColumnKind>(
+    mask: &Mask,
+    mut evaluate: impl FnMut(usize) -> TypedRow<K::Scalar>,
+) -> KernelResult<K> {
+    let mut values = Vec::with_capacity(mask.len());
+    let mut valid = Vec::with_capacity(mask.len());
+    let mut ok = Mask::all(mask.len());
+    let mut errors = Vec::new();
+
+    for row in 0..mask.len() {
+        let outcome = if mask[row] {
+            evaluate(row)
+        } else {
+            TypedRow::Inactive
+        };
+        match outcome {
+            TypedRow::Value(value) => {
+                values.push(value);
+                valid.push(true);
+            }
+            TypedRow::Null => {
+                values.push(K::placeholder());
+                valid.push(false);
+            }
+            TypedRow::Inactive => {
+                values.push(K::placeholder());
+                valid.push(true);
+            }
+            TypedRow::Error(error) => {
+                values.push(K::placeholder());
+                valid.push(true);
+                ok.set(row, false);
+                errors.push((row, error));
+            }
+        }
+    }
+
+    KernelResult {
+        column: KernelColumn::from_values(values, Validity::from_valid_bits(valid)),
+        ok,
+        errors,
+    }
+}
+
+fn eval_unary<I: ColumnKind, O: ColumnKind>(
+    input: &KernelColumn<I>,
+    mask: &Mask,
+    mut operation: impl FnMut(&I::Scalar) -> Result<O::Scalar, EvalError>,
+) -> KernelResult<O> {
+    eval_rows(mask, |row| match input.value(row) {
+        Some(value) => operation(value)
+            .map(TypedRow::Value)
+            .unwrap_or_else(TypedRow::Error),
+        None => TypedRow::Null,
+    })
+}
+
+fn eval_binary<A: ColumnKind, B: ColumnKind, O: ColumnKind>(
+    a: &KernelColumn<A>,
+    b: &KernelColumn<B>,
+    mask: &Mask,
+    mut operation: impl FnMut(&A::Scalar, &B::Scalar) -> Result<O::Scalar, EvalError>,
+) -> KernelResult<O> {
+    eval_rows(mask, |row| match (a.value(row), b.value(row)) {
+        (Some(a), Some(b)) => operation(a, b)
+            .map(TypedRow::Value)
+            .unwrap_or_else(TypedRow::Error),
+        _ => TypedRow::Null,
+    })
+}
+
+fn eval_ternary<A: ColumnKind, B: ColumnKind, C: ColumnKind, O: ColumnKind>(
+    a: &KernelColumn<A>,
+    b: &KernelColumn<B>,
+    c: &KernelColumn<C>,
+    mask: &Mask,
+    mut operation: impl FnMut(&A::Scalar, &B::Scalar, &C::Scalar) -> Result<O::Scalar, EvalError>,
+) -> KernelResult<O> {
+    eval_rows(mask, |row| {
+        match (a.value(row), b.value(row), c.value(row)) {
+            (Some(a), Some(b), Some(c)) => operation(a, b, c)
+                .map(TypedRow::Value)
+                .unwrap_or_else(TypedRow::Error),
+            _ => TypedRow::Null,
+        }
+    })
+}
+
+pub(crate) fn eval_empty(
+    value: Option<KernelColumn<AnyKind>>,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_rows(mask, |row| {
+        let is_empty = match value.as_ref().and_then(|value| value.value(row)) {
+            None => true,
+            Some(Value::Number(value)) => *value == 0.0,
+            Some(Value::Text(value)) => value.is_empty(),
+            Some(Value::List(value)) => value.is_empty(),
+            Some(Value::Bool(value)) => !value,
+            Some(Value::Date(_)) => false,
+        };
+        TypedRow::Value(is_empty)
+    })
+}
+
+pub(crate) fn eval_length(value: KernelColumn<AnyKind>, mask: &Mask) -> KernelResult<NumberKind> {
+    eval_unary(&value, mask, |value| match value {
+        Value::Text(value) => Ok(value.chars().count() as f64),
+        Value::List(value) => Ok(value.len() as f64),
+        _ => Err(EvalError::TypeMismatch),
+    })
+}
+
+pub(crate) fn eval_format<C: BuiltinValueContext>(
+    value: KernelColumn<AnyKind>,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_rows(mask, |row| match value.value(row) {
+        None => TypedRow::Value(String::new()),
+        Some(Value::Date(value)) => local_datetime(*value, context)
+            .map(|date| date.format("%B %-d, %Y %H:%M").to_string())
+            .map(TypedRow::Value)
+            .unwrap_or_else(TypedRow::Error),
+        Some(value) => TypedRow::Value(stringify_value(value)),
+    })
+}
+
+pub(crate) fn eval_equality(
+    a: KernelColumn<AnyKind>,
+    b: KernelColumn<AnyKind>,
+    negate: bool,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_rows(mask, |row| {
+        let equal = match (a.value(row), b.value(row)) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        };
+        TypedRow::Value(if negate { !equal } else { equal })
+    })
+}
+
+pub(crate) fn eval_substring(
+    text: KernelColumn<TextKind>,
+    start: KernelColumn<NumberKind>,
+    end: Option<KernelColumn<NumberKind>>,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_rows(mask, |row| {
+        let (Some(text), Some(start)) = (text.value(row), start.value(row)) else {
+            return TypedRow::Null;
+        };
+        if !start.is_finite() {
+            return TypedRow::Error(EvalError::InvalidArgument);
+        }
+        let characters = text.chars().collect::<Vec<_>>();
+        let start = normalize_index(*start, characters.len(), true);
+        let end = match end.as_ref() {
+            None => characters.len(),
+            Some(end) => {
+                let Some(end) = end.value(row) else {
+                    return TypedRow::Null;
+                };
+                if !end.is_finite() {
+                    return TypedRow::Error(EvalError::InvalidArgument);
+                }
+                normalize_index(*end, characters.len(), true)
+            }
+        };
+        let output = if start <= end {
+            characters[start..end].iter().collect()
+        } else {
+            String::new()
+        };
+        TypedRow::Value(output)
+    })
+}
+
+pub(crate) fn eval_contains(
+    text: KernelColumn<TextKind>,
+    search: KernelColumn<TextKind>,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_binary(&text, &search, mask, |text, search| {
+        Ok(text.contains(search))
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum RegexOperation {
+    Test,
+    Match,
+    ReplaceOne,
+    ReplaceAll,
+}
+
+pub(crate) fn eval_regex<O: ColumnKind>(
+    text: KernelColumn<TextKind>,
+    pattern: KernelColumn<TextKind>,
+    replacement: Option<KernelColumn<TextKind>>,
+    operation: RegexOperation,
+    mask: &Mask,
+) -> KernelResult<O> {
+    eval_rows(mask, |row| {
+        let (Some(text), Some(pattern)) = (text.value(row), pattern.value(row)) else {
+            return TypedRow::Null;
+        };
+        let replacement = match replacement.as_ref() {
+            Some(replacement) => {
+                let Some(replacement) = replacement.value(row) else {
+                    return TypedRow::Null;
+                };
+                Some(replacement.as_str())
+            }
+            None => None,
+        };
+        let regex = match Regex::new(pattern) {
+            Ok(regex) => regex,
+            Err(_) => return TypedRow::Error(EvalError::InvalidRegex),
+        };
+        let value = match operation {
+            RegexOperation::Test => Value::Bool(regex.is_match(text)),
+            RegexOperation::Match => Value::List(
+                regex
+                    .find_iter(text)
+                    .map(|matched| Value::Text(matched.as_str().to_string()))
+                    .collect(),
+            ),
+            RegexOperation::ReplaceOne | RegexOperation::ReplaceAll => {
+                let Some(replacement) = replacement else {
+                    return TypedRow::Error(EvalError::InvalidArgument);
+                };
+                let replaced = if matches!(operation, RegexOperation::ReplaceOne) {
+                    regex.replace(text, replacement)
+                } else {
+                    regex.replace_all(text, replacement)
+                };
+                Value::Text(replaced.into_owned())
+            }
+        };
+        O::from_value(value)
+            .map(TypedRow::Value)
+            .unwrap_or_else(|_| TypedRow::Error(EvalError::TypeMismatch))
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TextTransform {
+    Lower,
+    Upper,
+    Trim,
+}
+
+pub(crate) fn eval_text_transform(
+    text: KernelColumn<TextKind>,
+    operation: TextTransform,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_unary(&text, mask, |text| {
+        Ok(match operation {
+            TextTransform::Lower => text.to_lowercase(),
+            TextTransform::Upper => text.to_uppercase(),
+            TextTransform::Trim => text.trim().to_string(),
+        })
+    })
+}
+
+pub(crate) fn eval_repeat(
+    text: KernelColumn<TextKind>,
+    times: KernelColumn<NumberKind>,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_binary(&text, &times, mask, |text, times| {
+        Ok(text.repeat(bounded_count(*times)?))
+    })
+}
+
+pub(crate) fn eval_pad(
+    text: KernelColumn<AnyKind>,
+    length: KernelColumn<NumberKind>,
+    pad: KernelColumn<TextKind>,
+    at_start: bool,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_ternary(&text, &length, &pad, mask, |value, length, pad| {
+        let text = match value {
+            Value::Text(text) => text.clone(),
+            Value::Number(number) => stringify_value(&Value::Number(*number)),
+            _ => return Err(EvalError::TypeMismatch),
+        };
+        let desired = bounded_count(*length)?;
+        let current = text.chars().count();
+        if current >= desired || pad.is_empty() {
+            return Ok(text);
+        }
+        let fill = pad
+            .chars()
+            .cycle()
+            .take(desired - current)
+            .collect::<String>();
+        Ok(if at_start { fill + &text } else { text + &fill })
+    })
+}
+
+pub(crate) fn eval_concat(args: ConcatArgs, mask: &Mask) -> KernelResult<ListKind> {
+    let groups = args.repeat_groups.into_vec();
+    eval_rows(mask, |row| {
+        let mut output = Vec::new();
+        for group in &groups {
+            let Some(values) = group.lists.value(row) else {
+                return TypedRow::Null;
+            };
+            output.extend(values.iter().cloned());
+        }
+        TypedRow::Value(output)
+    })
+}
+
+pub(crate) fn eval_join(
+    list: KernelColumn<ListKind>,
+    separator: KernelColumn<TextKind>,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_binary(&list, &separator, mask, |list, separator| {
+        Ok(list
+            .iter()
+            .map(stringify_value)
+            .collect::<Vec<_>>()
+            .join(separator))
+    })
+}
+
+pub(crate) fn eval_split(
+    text: KernelColumn<TextKind>,
+    separator: KernelColumn<TextKind>,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    eval_binary(&text, &separator, mask, |text, separator| {
+        if separator.is_empty() {
+            Ok(text
+                .chars()
+                .map(|character| Value::Text(character.to_string()))
+                .collect())
+        } else {
+            Ok(text
+                .split(separator)
+                .map(|part| Value::Text(part.to_string()))
+                .collect())
+        }
+    })
+}
+
+pub(crate) fn eval_format_number(
+    value: KernelColumn<NumberKind>,
+    format: KernelColumn<TextKind>,
+    precision: KernelColumn<NumberKind>,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_ternary(
+        &value,
+        &format,
+        &precision,
+        mask,
+        |value, format, precision| {
+            if !value.is_finite() {
+                return Err(EvalError::InvalidArgument);
+            }
+            let precision = bounded_count(*precision)?.min(100);
+            let format = format.to_ascii_lowercase();
+            match format.as_str() {
+                "number" | "decimal" => Ok(render_fixed(*value, precision, false)),
+                "number_with_commas" | "commas" => Ok(render_fixed(*value, precision, true)),
+                "percent" | "%" => {
+                    let percent = *value * 100.0;
+                    if !percent.is_finite() {
+                        return Err(EvalError::InvalidArgument);
+                    }
+                    Ok(format!("{}%", render_fixed(percent, precision, false)))
+                }
+                "scientific" => Ok(format!("{value:.*e}", precision)),
+                "usd" => Ok(render_currency(*value, precision, "$")),
+                "eur" => Ok(render_currency(*value, precision, "€")),
+                "gbp" => Ok(render_currency(*value, precision, "£")),
+                "jpy" => Ok(render_currency(*value, precision, "¥")),
+                "cny" => Ok(render_currency(*value, precision, "CN¥")),
+                "krw" => Ok(render_currency(*value, precision, "₩")),
+                "inr" => Ok(render_currency(*value, precision, "₹")),
+                "cad" => Ok(render_currency(*value, precision, "CA$")),
+                "aud" => Ok(render_currency(*value, precision, "A$")),
+                "chf" => Ok(render_currency(*value, precision, "CHF ")),
+                _ => Err(EvalError::InvalidArgument),
+            }
+        },
+    )
+}
+
+fn render_currency(value: f64, precision: usize, symbol: &str) -> String {
+    let sign = if value.is_sign_negative() { "-" } else { "" };
+    format!(
+        "{sign}{symbol}{}",
+        render_fixed(value.abs(), precision, true)
+    )
+}
+
+fn render_fixed(value: f64, precision: usize, grouped: bool) -> String {
+    let rendered = format!("{value:.*}", precision);
+    if !grouped {
+        return rendered;
+    }
+
+    let (sign, unsigned) = rendered
+        .strip_prefix('-')
+        .map_or(("", rendered.as_str()), |value| ("-", value));
+    let (integer, fraction) = unsigned
+        .split_once('.')
+        .map_or((unsigned, None), |(integer, fraction)| {
+            (integer, Some(fraction))
+        });
+    let mut grouped_integer = String::with_capacity(integer.len() + integer.len() / 3);
+    for (index, character) in integer.chars().enumerate() {
+        if index > 0 && (integer.len() - index).is_multiple_of(3) {
+            grouped_integer.push(',');
+        }
+        grouped_integer.push(character);
+    }
+    match fraction {
+        Some(fraction) => format!("{sign}{grouped_integer}.{fraction}"),
+        None => format!("{sign}{grouped_integer}"),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum NumericBinary {
+    Add,
+    Subtract,
+    Multiply,
+    Mod,
+    Pow,
+    Divide,
+}
+
+pub(crate) fn eval_numeric_binary(
+    a: KernelColumn<NumberKind>,
+    b: KernelColumn<NumberKind>,
+    operation: NumericBinary,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_binary(&a, &b, mask, |a, b| {
+        let value = match operation {
+            NumericBinary::Add => *a + *b,
+            NumericBinary::Subtract => *a - *b,
+            NumericBinary::Multiply => *a * *b,
+            NumericBinary::Mod if *b != 0.0 => *a % *b,
+            NumericBinary::Pow => a.powf(*b),
+            NumericBinary::Divide if *b != 0.0 => *a / *b,
+            NumericBinary::Mod | NumericBinary::Divide => return Err(EvalError::DivideByZero),
+        };
+        finite_number(value)
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Aggregate {
+    Min,
+    Max,
+    Sum,
+    Median,
+    Mean,
+}
+
+pub(crate) fn eval_aggregate(
+    columns: Vec<KernelColumn<AnyKind>>,
+    operation: Aggregate,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_rows(mask, |row| {
+        let mut values = Vec::new();
+        for column in &columns {
+            let Some(value) = column.value(row) else {
+                return TypedRow::Null;
+            };
+            match value {
+                Value::Number(value) if value.is_finite() => values.push(*value),
+                Value::List(items) => {
+                    for item in items {
+                        match item {
+                            Value::Number(value) if value.is_finite() => values.push(*value),
+                            _ => return TypedRow::Error(EvalError::TypeMismatch),
+                        }
+                    }
+                }
+                _ => return TypedRow::Error(EvalError::TypeMismatch),
+            }
+        }
+        if values.is_empty() {
+            return TypedRow::Null;
+        }
+        let result = match operation {
+            Aggregate::Min => values.into_iter().fold(f64::INFINITY, f64::min),
+            Aggregate::Max => values.into_iter().fold(f64::NEG_INFINITY, f64::max),
+            Aggregate::Sum => values.into_iter().sum(),
+            Aggregate::Mean => values.iter().sum::<f64>() / values.len() as f64,
+            Aggregate::Median => {
+                values.sort_by(f64::total_cmp);
+                let middle = values.len() / 2;
+                if values.len() % 2 == 0 {
+                    (values[middle - 1] + values[middle]) / 2.0
+                } else {
+                    values[middle]
+                }
+            }
+        };
+        finite_number(result)
+            .map(TypedRow::Value)
+            .unwrap_or_else(TypedRow::Error)
+    })
+}
+
+pub(crate) fn eval_round(
+    value: KernelColumn<NumberKind>,
+    places: Option<KernelColumn<NumberKind>>,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_rows(mask, |row| {
+        let Some(value) = value.value(row) else {
+            return TypedRow::Null;
+        };
+        let places = match places.as_ref() {
+            None => 0,
+            Some(places) => {
+                let Some(places) = places.value(row) else {
+                    return TypedRow::Null;
+                };
+                if !places.is_finite() {
+                    return TypedRow::Error(EvalError::InvalidArgument);
+                }
+                places.trunc().clamp(-308.0, 308.0) as i32
+            }
+        };
+        let factor = 10_f64.powi(places);
+        finite_number((value * factor).round() / factor)
+            .map(TypedRow::Value)
+            .unwrap_or_else(TypedRow::Error)
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum NumericUnary {
+    Floor,
+    Cbrt,
+    Exp,
+    Ln,
+    Log10,
+    Log2,
+    Sign,
+}
+
+pub(crate) fn eval_numeric_unary(
+    value: KernelColumn<NumberKind>,
+    operation: NumericUnary,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_unary(&value, mask, |value| {
+        let result = match operation {
+            NumericUnary::Floor => value.floor(),
+            NumericUnary::Cbrt => value.cbrt(),
+            NumericUnary::Exp => value.exp(),
+            NumericUnary::Ln if *value > 0.0 => value.ln(),
+            NumericUnary::Log10 if *value > 0.0 => value.log10(),
+            NumericUnary::Log2 if *value > 0.0 => value.log2(),
+            NumericUnary::Sign if *value == 0.0 => 0.0,
+            NumericUnary::Sign => value.signum(),
+            NumericUnary::Ln | NumericUnary::Log10 | NumericUnary::Log2 => {
+                return Err(EvalError::InvalidArgument);
+            }
+        };
+        finite_number(result)
+    })
+}
+
+pub(crate) fn eval_constant_number(value: f64, mask: &Mask) -> KernelResult<NumberKind> {
+    eval_rows(mask, |_| TypedRow::Value(value))
+}
+
+pub(crate) fn eval_to_number(
+    value: KernelColumn<AnyKind>,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_unary(&value, mask, |value| {
+        let number = match value {
+            Value::Number(value) => *value,
+            Value::Bool(value) => {
+                if *value {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            Value::Date(value) => *value as f64,
+            Value::Text(value) => value
+                .trim()
+                .parse::<f64>()
+                .map_err(|_| EvalError::InvalidArgument)?,
+            Value::List(_) => return Err(EvalError::TypeMismatch),
+        };
+        finite_number(number)
+    })
+}
+
+pub(crate) fn abs_number(value: f64) -> f64 {
+    value.abs()
+}
+
+pub(crate) fn ceil_number(value: f64) -> f64 {
+    value.ceil()
+}
+
+pub(crate) fn sqrt_number(value: f64) -> Result<f64, EvalError> {
+    if value < 0.0 || !value.is_finite() {
+        Err(EvalError::InvalidArgument)
+    } else {
+        Ok(value.sqrt())
+    }
+}
+
+pub(crate) fn eval_abs(column: KernelColumn<NumberKind>, mask: &Mask) -> KernelResult<NumberKind> {
+    let input_validity = column.validity().clone();
+    let valid = (0..mask.len())
+        .map(|row| !mask[row] || input_validity.is_valid(row))
+        .collect();
+    let validity = Validity::from_valid_bits(valid);
+    let column = match column.try_into_unique() {
+        Ok((mut storage, _)) => {
+            for (row, value) in storage.iter_mut().enumerate() {
+                if mask[row] && input_validity.is_valid(row) {
+                    *value = abs_number(*value);
+                }
+            }
+            KernelColumn::from_owned(storage, validity)
+        }
+        Err(column) => {
+            let values = column
+                .values()
+                .iter()
+                .enumerate()
+                .map(|(row, value)| {
+                    if mask[row] && input_validity.is_valid(row) {
+                        abs_number(*value)
+                    } else {
+                        *value
+                    }
+                })
+                .collect();
+            KernelColumn::from_values(values, validity)
+        }
+    };
+    KernelResult {
+        column,
+        ok: Mask::all(mask.len()),
+        errors: Vec::new(),
+    }
+}
+
+pub(crate) fn eval_now<C: BuiltinValueContext>(context: &C, mask: &Mask) -> KernelResult<DateKind> {
+    let value = context.runtime().evaluated_at_epoch_ms();
+    eval_rows(mask, |_| TypedRow::Value(value))
+}
+
+pub(crate) fn eval_today<C: BuiltinValueContext>(
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<DateKind> {
+    match today_epoch_ms(context) {
+        Ok(value) => eval_rows(mask, |_| TypedRow::Value(value)),
+        Err(error) => eval_rows(mask, |_| TypedRow::Error(error.clone())),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum DatePart {
+    Minute,
+    Hour,
+    Day,
+    Date,
+    Week,
+    Month,
+    Year,
+}
+
+pub(crate) fn eval_date_part<C: BuiltinValueContext>(
+    date: KernelColumn<DateKind>,
+    part: DatePart,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_unary(&date, mask, |date| {
+        let date = local_datetime(*date, context)?;
+        Ok(match part {
+            DatePart::Minute => date.minute() as f64,
+            DatePart::Hour => date.hour() as f64,
+            DatePart::Day => date.weekday().number_from_monday() as f64,
+            DatePart::Date => date.day() as f64,
+            DatePart::Week => date.iso_week().week() as f64,
+            DatePart::Month => date.month() as f64,
+            DatePart::Year => date.year() as f64,
+        })
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum DateShift {
+    Add,
+    Subtract,
+}
+
+pub(crate) fn eval_date_shift<C: BuiltinValueContext>(
+    date: KernelColumn<DateKind>,
+    amount: KernelColumn<NumberKind>,
+    unit: KernelColumn<TextKind>,
+    direction: DateShift,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<DateKind> {
+    eval_ternary(&date, &amount, &unit, mask, |date, amount, unit| {
+        if !amount.is_finite() {
+            return Err(EvalError::InvalidDate);
+        }
+        let mut amount = amount.trunc() as i64;
+        if matches!(direction, DateShift::Subtract) {
+            amount = amount.checked_neg().ok_or(EvalError::InvalidDate)?;
+        }
+        let unit = DateUnit::parse(unit)?;
+        let shifted = if let Some(milliseconds) = unit.fixed_milliseconds() {
+            date.checked_add(
+                amount
+                    .checked_mul(milliseconds)
+                    .ok_or(EvalError::InvalidDate)?,
+            )
+        } else {
+            let months = amount
+                .checked_mul(unit.month_multiplier().ok_or(EvalError::InvalidArgument)?)
+                .ok_or(EvalError::InvalidDate)?;
+            shift_months(*date, months, context)
+        }
+        .ok_or(EvalError::InvalidDate)?;
+        Ok(shifted)
+    })
+}
+
+pub(crate) fn eval_date_between<C: BuiltinValueContext>(
+    a: KernelColumn<DateKind>,
+    b: KernelColumn<DateKind>,
+    unit: KernelColumn<TextKind>,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_ternary(&a, &b, &unit, mask, |a, b, unit| {
+        let unit = DateUnit::parse(unit)?;
+        let value = match unit {
+            DateUnit::Minute | DateUnit::Hour | DateUnit::Day | DateUnit::Week => {
+                let difference = a.checked_sub(*b).ok_or(EvalError::InvalidDate)?;
+                let milliseconds = unit
+                    .fixed_milliseconds()
+                    .ok_or(EvalError::InvalidArgument)?;
+                (difference as f64 / milliseconds as f64).trunc()
+            }
+            DateUnit::Month => complete_months_between(*a, *b, context)? as f64,
+            DateUnit::Quarter => complete_months_between(*a, *b, context)? as f64 / 3.0,
+            DateUnit::Year => complete_months_between(*a, *b, context)? as f64 / 12.0,
+        };
+        Ok(value.trunc())
+    })
+}
+
+fn complete_months_between<C: BuiltinValueContext>(
+    a: i64,
+    b: i64,
+    context: &C,
+) -> Result<i64, EvalError> {
+    if a < b {
+        return complete_months_between(b, a, context)?
+            .checked_neg()
+            .ok_or(EvalError::InvalidDate);
+    }
+
+    let a_local = local_datetime(a, context)?;
+    let b_local = local_datetime(b, context)?;
+    let months = i64::from(a_local.year() - b_local.year())
+        .checked_mul(12)
+        .and_then(|years| {
+            years.checked_add(i64::from(a_local.month()) - i64::from(b_local.month()))
+        })
+        .ok_or(EvalError::InvalidDate)?;
+    let candidate = shift_months(b, months, context).ok_or(EvalError::InvalidDate)?;
+    if candidate > a {
+        months.checked_sub(1).ok_or(EvalError::InvalidDate)
+    } else {
+        Ok(months)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DateUnit {
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+impl DateUnit {
+    fn parse(value: &str) -> Result<Self, EvalError> {
+        match value.to_ascii_lowercase().as_str() {
+            "minute" | "minutes" => Ok(Self::Minute),
+            "hour" | "hours" => Ok(Self::Hour),
+            "day" | "days" => Ok(Self::Day),
+            "week" | "weeks" => Ok(Self::Week),
+            "month" | "months" => Ok(Self::Month),
+            "quarter" | "quarters" => Ok(Self::Quarter),
+            "year" | "years" => Ok(Self::Year),
+            _ => Err(EvalError::InvalidArgument),
+        }
+    }
+
+    fn fixed_milliseconds(self) -> Option<i64> {
+        match self {
+            Self::Minute => Some(60_000),
+            Self::Hour => Some(3_600_000),
+            Self::Day => Some(86_400_000),
+            Self::Week => Some(604_800_000),
+            Self::Month | Self::Quarter | Self::Year => None,
+        }
+    }
+
+    fn month_multiplier(self) -> Option<i64> {
+        match self {
+            Self::Month => Some(1),
+            Self::Quarter => Some(3),
+            Self::Year => Some(12),
+            Self::Minute | Self::Hour | Self::Day | Self::Week => None,
+        }
+    }
+}
+
+pub(crate) fn eval_timestamp(
+    date: KernelColumn<DateKind>,
+    mask: &Mask,
+) -> KernelResult<NumberKind> {
+    eval_unary(&date, mask, |date| Ok(*date as f64))
+}
+
+pub(crate) fn eval_from_timestamp(
+    timestamp: KernelColumn<NumberKind>,
+    mask: &Mask,
+) -> KernelResult<DateKind> {
+    eval_unary(&timestamp, mask, |timestamp| {
+        if !timestamp.is_finite() || *timestamp < i64::MIN as f64 || *timestamp >= i64::MAX as f64 {
+            return Err(EvalError::InvalidDate);
+        }
+        let timestamp = timestamp.trunc() as i64;
+        timestamp
+            .checked_sub(timestamp.rem_euclid(60_000))
+            .ok_or(EvalError::InvalidDate)
+    })
+}
+
+pub(crate) fn eval_format_date<C: BuiltinValueContext>(
+    date: KernelColumn<DateKind>,
+    format: KernelColumn<TextKind>,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<TextKind> {
+    eval_binary(&date, &format, mask, |date, format| {
+        Ok(local_datetime(*date, context)?
+            .format(&translate_date_format(format))
+            .to_string())
+    })
+}
+
+pub(crate) fn eval_parse_date<C: BuiltinValueContext>(
+    text: KernelColumn<TextKind>,
+    context: &C,
+    mask: &Mask,
+) -> KernelResult<DateKind> {
+    eval_unary(&text, mask, |text| {
+        if let Ok(date) = chrono::DateTime::parse_from_rfc3339(text) {
+            return Ok(date.timestamp_millis());
+        }
+        let date =
+            NaiveDate::parse_from_str(text, "%Y-%m-%d").map_err(|_| EvalError::InvalidDate)?;
+        let local = timezone(context)?
+            .from_local_datetime(&date.and_hms_opt(0, 0, 0).ok_or(EvalError::InvalidDate)?)
+            .single()
+            .ok_or(EvalError::InvalidDate)?;
+        Ok(local.timestamp_millis())
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ListPick {
+    At,
+    First,
+    Last,
+}
+
+pub(crate) fn eval_list_pick(
+    list: KernelColumn<ListKind>,
+    index: Option<KernelColumn<NumberKind>>,
+    operation: ListPick,
+    mask: &Mask,
+) -> KernelResult<AnyKind> {
+    eval_rows(mask, |row| {
+        let Some(list) = list.value(row) else {
+            return TypedRow::Null;
+        };
+        let value = match operation {
+            ListPick::First => list.first(),
+            ListPick::Last => list.last(),
+            ListPick::At => {
+                let Some(index) = index.as_ref().and_then(|index| index.value(row)) else {
+                    return TypedRow::Null;
+                };
+                if !index.is_finite() {
+                    return TypedRow::Error(EvalError::InvalidArgument);
+                }
+                list_index(*index, list.len()).and_then(|index| list.get(index))
+            }
+        };
+        value.cloned().map_or(TypedRow::Null, TypedRow::Value)
+    })
+}
+
+pub(crate) fn eval_slice(
+    list: KernelColumn<ListKind>,
+    start: KernelColumn<NumberKind>,
+    end: Option<KernelColumn<NumberKind>>,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    eval_rows(mask, |row| {
+        let (Some(list), Some(start)) = (list.value(row), start.value(row)) else {
+            return TypedRow::Null;
+        };
+        if !start.is_finite() {
+            return TypedRow::Error(EvalError::InvalidArgument);
+        }
+        let start = normalize_index(*start, list.len(), true);
+        let end = match end.as_ref() {
+            None => list.len(),
+            Some(end) => {
+                let Some(end) = end.value(row) else {
+                    return TypedRow::Null;
+                };
+                if !end.is_finite() {
+                    return TypedRow::Error(EvalError::InvalidArgument);
+                }
+                normalize_index(*end, list.len(), true)
+            }
+        };
+        TypedRow::Value(if start <= end {
+            list[start..end].to_vec()
+        } else {
+            Vec::new()
+        })
+    })
+}
+
+pub(crate) fn eval_splice(args: SpliceArgs, mask: &Mask) -> KernelResult<ListKind> {
+    let groups = args.repeat_groups.into_vec();
+    eval_rows(mask, |row| {
+        let (Some(list), Some(start), Some(delete_count)) = (
+            args.list.value(row),
+            args.start_index.value(row),
+            args.delete_count.value(row),
+        ) else {
+            return TypedRow::Null;
+        };
+        if !start.is_finite() || !delete_count.is_finite() {
+            return TypedRow::Error(EvalError::InvalidArgument);
+        }
+        let start = normalize_index(*start, list.len(), true);
+        let delete_count = if *delete_count > 0.0 {
+            delete_count.trunc() as usize
+        } else {
+            0
+        };
+        let end = start.saturating_add(delete_count).min(list.len());
+        let mut output = list[..start].to_vec();
+        for group in &groups {
+            let Some(item) = group.items.value(row) else {
+                return TypedRow::Null;
+            };
+            output.push(item.clone());
+        }
+        output.extend_from_slice(&list[end..]);
+        TypedRow::Value(output)
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ListTransform {
+    Sort,
+    Reverse,
+    Unique,
+}
+
+pub(crate) fn eval_list_transform(
+    list: KernelColumn<ListKind>,
+    operation: ListTransform,
+    mask: &Mask,
+) -> KernelResult<ListKind> {
+    eval_unary(&list, mask, |list| {
+        let mut values = list.clone();
+        match operation {
+            ListTransform::Sort => values.sort_by(compare_value),
+            ListTransform::Reverse => values.reverse(),
+            ListTransform::Unique => {
+                let mut unique = Vec::with_capacity(values.len());
+                for value in values {
+                    if !unique.contains(&value) {
+                        unique.push(value);
+                    }
+                }
+                values = unique;
+            }
+        }
+        Ok(values)
+    })
+}
+
+pub(crate) fn eval_includes(
+    list: KernelColumn<ListKind>,
+    value: KernelColumn<AnyKind>,
+    mask: &Mask,
+) -> KernelResult<BooleanKind> {
+    eval_binary(&list, &value, mask, |list, value| Ok(list.contains(value)))
+}
+
+pub(crate) fn eval_flat(list: KernelColumn<ListKind>, mask: &Mask) -> KernelResult<ListKind> {
+    eval_unary(&list, mask, |list| {
+        let mut output = Vec::new();
+        flatten_values(list, &mut output);
+        Ok(output)
+    })
+}
+
+pub(crate) fn eval_id<C: BuiltinValueContext>(context: &C, mask: &Mask) -> KernelResult<TextKind> {
+    eval_rows(mask, |row| TypedRow::Value(context.rows()[row].to_string()))
+}
+
+fn finite_number(value: f64) -> Result<f64, EvalError> {
+    value
+        .is_finite()
+        .then_some(value)
+        .ok_or(EvalError::InvalidArgument)
+}
+
+fn bounded_count(value: f64) -> Result<usize, EvalError> {
+    if !value.is_finite() || !(0.0..=1_000_000.0).contains(&value) {
+        return Err(EvalError::InvalidArgument);
+    }
+    Ok(value.trunc() as usize)
+}
+
+fn timezone(context: &impl BuiltinValueContext) -> Result<FixedOffset, EvalError> {
+    context
+        .runtime()
+        .timezone_offset_minutes()
+        .checked_mul(60)
+        .and_then(FixedOffset::east_opt)
+        .ok_or(EvalError::InvalidDate)
+}
+
+fn local_datetime(
+    epoch_ms: i64,
+    context: &impl BuiltinValueContext,
+) -> Result<chrono::DateTime<FixedOffset>, EvalError> {
+    let utc =
+        chrono::DateTime::<Utc>::from_timestamp_millis(epoch_ms).ok_or(EvalError::InvalidDate)?;
+    Ok(utc.with_timezone(&timezone(context)?))
+}
+
+fn today_epoch_ms(context: &impl BuiltinValueContext) -> Result<i64, EvalError> {
+    let offset_ms = i64::from(timezone(context)?.local_minus_utc())
+        .checked_mul(1_000)
+        .ok_or(EvalError::InvalidDate)?;
+    let local_epoch = context
+        .runtime()
+        .evaluated_at_epoch_ms()
+        .checked_add(offset_ms)
+        .ok_or(EvalError::InvalidDate)?;
+    local_epoch
+        .div_euclid(86_400_000)
+        .checked_mul(86_400_000)
+        .and_then(|midnight| midnight.checked_sub(offset_ms))
+        .ok_or(EvalError::InvalidDate)
+}
+
+fn shift_months(epoch_ms: i64, amount: i64, context: &impl BuiltinValueContext) -> Option<i64> {
+    let local = local_datetime(epoch_ms, context).ok()?;
+    let magnitude = u32::try_from(amount.unsigned_abs()).ok()?;
+    let shifted = if amount >= 0 {
+        local.checked_add_months(Months::new(magnitude))?
+    } else {
+        local.checked_sub_months(Months::new(magnitude))?
+    };
+    Some(shifted.timestamp_millis())
+}
+
+fn translate_date_format(format: &str) -> String {
+    const TOKENS: &[(&str, &str)] = &[
+        ("YYYY", "%Y"),
+        ("MMMM", "%B"),
+        ("MMM", "%b"),
+        ("dddd", "%A"),
+        ("ddd", "%a"),
+        ("YY", "%y"),
+        ("MM", "%m"),
+        ("DD", "%d"),
+        ("HH", "%H"),
+        ("hh", "%I"),
+        ("mm", "%M"),
+        ("ss", "%S"),
+        ("Y", "%Y"),
+        ("M", "%-m"),
+        ("D", "%-d"),
+        ("H", "%-H"),
+        ("h", "%-I"),
+        ("m", "%-M"),
+        ("s", "%-S"),
+        ("A", "%p"),
+        ("a", "%P"),
+    ];
+
+    let mut output = String::with_capacity(format.len());
+    let mut remaining = format;
+    while !remaining.is_empty() {
+        if let Some((token, replacement)) = TOKENS
+            .iter()
+            .find(|(token, _)| remaining.starts_with(token))
+        {
+            output.push_str(replacement);
+            remaining = &remaining[token.len()..];
+            continue;
+        }
+
+        let character = remaining
+            .chars()
+            .next()
+            .expect("non-empty format has a character");
+        if character == '%' {
+            output.push_str("%%");
+        } else {
+            output.push(character);
+        }
+        remaining = &remaining[character.len_utf8()..];
+    }
+    output
+}
+
+fn list_index(index: f64, len: usize) -> Option<usize> {
+    let index = index.trunc() as isize;
+    let len = len as isize;
+    let index = if index < 0 {
+        len.checked_add(index)?
+    } else {
+        index
+    };
+    (0..len).contains(&index).then_some(index as usize)
+}
+
+fn normalize_index(index: f64, len: usize, allow_end: bool) -> usize {
+    let index = index.trunc() as isize;
+    let len = len as isize;
+    let normalized = if index < 0 { len + index } else { index };
+    let maximum = if allow_end {
+        len
+    } else {
+        len.saturating_sub(1)
+    };
+    normalized.clamp(0, maximum) as usize
+}
+
+fn compare_value(left: &Value, right: &Value) -> Ordering {
+    match (left, right) {
+        (Value::Number(left), Value::Number(right)) => left.total_cmp(right),
+        (Value::Text(left), Value::Text(right)) => left.cmp(right),
+        (Value::Bool(left), Value::Bool(right)) => left.cmp(right),
+        (Value::Date(left), Value::Date(right)) => left.cmp(right),
+        (Value::List(left), Value::List(right)) => left.len().cmp(&right.len()),
+        (left, right) => value_rank(left).cmp(&value_rank(right)),
+    }
+}
+
+fn value_rank(value: &Value) -> u8 {
+    match value {
+        Value::Number(_) => 0,
+        Value::Text(_) => 1,
+        Value::Bool(_) => 2,
+        Value::Date(_) => 3,
+        Value::List(_) => 4,
+    }
+}
+
+fn flatten_values(values: &[Value], output: &mut Vec<Value>) {
+    for value in values {
+        match value {
+            Value::List(nested) => flatten_values(nested, output),
+            value => output.push(value.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abs_reuses_uniquely_owned_storage_for_in_place_work() {
+        let input =
+            KernelColumn::<NumberKind>::from_values(vec![-1.0, 2.0, -3.0], Validity::AllValid);
+        let storage_address = input.values().as_ptr() as usize;
+
+        let output = eval_abs(input, &Mask::all(3));
+
+        assert_eq!(output.column.values(), &[1.0, 2.0, 3.0]);
+        assert_eq!(output.column.values().as_ptr() as usize, storage_address);
+    }
+}

--- a/evaluator/tests/builtin_behavior.rs
+++ b/evaluator/tests/builtin_behavior.rs
@@ -1,0 +1,227 @@
+use analyzer::analysis::{Property, Ty};
+use evaluator::{
+    BooleanKind, BuiltinRuntimeContext, Column, EvalContext, EvalInputsBuilder, KernelColumn,
+    PreparedFormula, RowBatch, RowId, Validity, Value, prepare_formula,
+};
+
+fn runtime() -> BuiltinRuntimeContext {
+    BuiltinRuntimeContext::new(1_700_000_123_456, 8 * 60)
+}
+
+fn batch(len: usize) -> RowBatch {
+    RowBatch::new((0..len).map(|index| RowId::from(format!("row-{index}"))), 7)
+}
+
+fn prepare(source: &str) -> PreparedFormula {
+    prepare_with_properties(source, &[])
+}
+
+fn prepare_with_properties(source: &str, properties: &[(&str, Ty)]) -> PreparedFormula {
+    let mut syntax = analyzer::analyze_syntax(source);
+    assert!(
+        syntax.diagnostics.is_empty(),
+        "parse diagnostics for `{source}`: {:?}",
+        syntax.diagnostics
+    );
+    let properties = properties
+        .iter()
+        .map(|(name, ty)| Property {
+            name: (*name).to_string(),
+            ty: ty.clone(),
+            disabled_reason: None,
+        })
+        .collect();
+    prepare_formula(&mut syntax.expr, &EvalContext::new(properties))
+        .unwrap_or_else(|error| panic!("failed to prepare `{source}`: {error:?}"))
+}
+
+fn evaluate(source: &str, len: usize) -> evaluator::EvalBlock {
+    let prepared = prepare(source);
+    let inputs = EvalInputsBuilder::new(runtime())
+        .finish(&prepared, len)
+        .expect("formula has no property inputs");
+    prepared
+        .evaluate(batch(len), inputs)
+        .expect("matching prepared input layout")
+}
+
+fn evaluate_with_columns(
+    source: &str,
+    properties: &[(&str, Ty)],
+    columns: &[(&str, Column)],
+    len: usize,
+) -> evaluator::EvalBlock {
+    let prepared = prepare_with_properties(source, properties);
+    let mut builder = EvalInputsBuilder::new(runtime());
+    for required in prepared.required_columns() {
+        let (_, column) = columns
+            .iter()
+            .find(|(name, _)| *name == required.name)
+            .unwrap_or_else(|| panic!("missing test column {}", required.name));
+        builder.insert(required.slot, column.clone());
+    }
+    let inputs = builder
+        .finish(&prepared, len)
+        .expect("test columns satisfy the prepared contract");
+    prepared
+        .evaluate(batch(len), inputs)
+        .expect("matching prepared input layout")
+}
+
+fn values(block: &evaluator::EvalBlock) -> Vec<Option<Value>> {
+    (0..block.len())
+        .map(|row| block.column.row_value(row))
+        .collect()
+}
+
+#[test]
+fn flat_recursively_flattens_the_resolved_dynamic_list() {
+    let output = evaluate(r#"flat([[1], [2, ["three"]]])"#, 1);
+
+    assert_eq!(
+        values(&output),
+        vec![Some(Value::List(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Text("three".to_string()),
+        ]))]
+    );
+    assert_eq!(output.ok.as_slice(), &[true]);
+    assert!(output.errors.is_empty());
+}
+
+#[test]
+fn concat_evaluates_every_repeat_group_in_order() {
+    let output = evaluate("concat([1], [2, 3], [4])", 1);
+
+    assert_eq!(
+        values(&output),
+        vec![Some(Value::List(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+            Value::Number(4.0),
+        ]))]
+    );
+    assert_eq!(output.ok.as_slice(), &[true]);
+    assert!(output.errors.is_empty());
+}
+
+#[test]
+fn splice_combines_its_fixed_head_with_zero_or_more_items() {
+    let output = evaluate("splice([1, 2, 3], 1, 1, 9, 8)", 1);
+
+    assert_eq!(
+        values(&output),
+        vec![Some(Value::List(vec![
+            Value::Number(1.0),
+            Value::Number(9.0),
+            Value::Number(8.0),
+            Value::Number(3.0),
+        ]))]
+    );
+    assert_eq!(output.ok.as_slice(), &[true]);
+    assert!(output.errors.is_empty());
+}
+
+#[test]
+fn ifs_selects_branches_lazily_and_isolates_row_errors() {
+    let first = Column::Boolean(KernelColumn::<BooleanKind>::from_values(
+        vec![true, false, false],
+        Validity::AllValid,
+    ));
+    let second = Column::Boolean(KernelColumn::<BooleanKind>::from_values(
+        vec![true, false, true],
+        Validity::AllValid,
+    ));
+    let output = evaluate_with_columns(
+        r#"ifs(prop("First"), 10, prop("Second"), divide(1, 0), 30)"#,
+        &[("First", Ty::Boolean), ("Second", Ty::Boolean)],
+        &[("First", first), ("Second", second)],
+        3,
+    );
+
+    assert_eq!(output.column.row_value(0), Some(Value::Number(10.0)));
+    assert_eq!(output.column.row_value(1), Some(Value::Number(30.0)));
+    assert_eq!(output.ok.as_slice(), &[true, true, false]);
+    assert_eq!(output.errors, vec![(2, evaluator::EvalError::DivideByZero)]);
+    assert!(output.validity().is_valid(2));
+}
+
+#[test]
+fn ifs_stops_evaluating_conditions_after_the_first_match() {
+    let first = Column::Boolean(KernelColumn::<BooleanKind>::from_values(
+        vec![true, false],
+        Validity::AllValid,
+    ));
+    let output = evaluate_with_columns(
+        r#"ifs(prop("First"), 10, divide(1, 0) > 0, 20, 30)"#,
+        &[("First", Ty::Boolean)],
+        &[("First", first)],
+        2,
+    );
+
+    assert_eq!(output.column.row_value(0), Some(Value::Number(10.0)));
+    assert_eq!(output.ok.as_slice(), &[true, false]);
+    assert_eq!(output.errors, vec![(1, evaluator::EvalError::DivideByZero)]);
+}
+
+#[test]
+fn runtime_snapshot_and_row_ids_feed_system_builtins() {
+    let now = evaluate("now()", 2);
+    assert_eq!(
+        values(&now),
+        vec![
+            Some(Value::Date(1_700_000_123_456)),
+            Some(Value::Date(1_700_000_123_456)),
+        ]
+    );
+
+    let today = evaluate("today()", 1);
+    assert_eq!(values(&today), vec![Some(Value::Date(1_699_977_600_000))]);
+
+    let ids = evaluate("id()", 2);
+    assert_eq!(
+        values(&ids),
+        vec![
+            Some(Value::Text("row-0".to_string())),
+            Some(Value::Text("row-1".to_string())),
+        ]
+    );
+}
+
+// Each case below failed against the initial PR3 implementation during its semantic audit.
+#[test]
+fn observed_value_regressions_remain_fixed() {
+    let cases = [
+        ("empty(0)", Value::Bool(true)),
+        ("empty(false)", Value::Bool(true)),
+        ("sign(0)", Value::Number(0.0)),
+        ("sign(-0)", Value::Number(0.0)),
+        (r#"substring("abc", 2, 1)"#, Value::Text(String::new())),
+        ("timestamp(fromTimestamp(42))", Value::Number(0.0)),
+        (
+            r#"formatDate(parseDate("2024-05-06"), "MMMM D, Y")"#,
+            Value::Text("May 6, 2024".to_string()),
+        ),
+        (
+            r#"format(parseDate("2024-05-06"))"#,
+            Value::Text("May 6, 2024 00:00".to_string()),
+        ),
+        (
+            r#"dateBetween(parseDate("2024-01-01"), parseDate("2023-01-01"), "years")"#,
+            Value::Number(1.0),
+        ),
+        (
+            r#"formatNumber(1234.5, "usd", 2)"#,
+            Value::Text("$1,234.50".to_string()),
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let output = evaluate(source, 1);
+        assert_eq!(values(&output), vec![Some(expected)], "{source}");
+        assert_eq!(output.ok.as_slice(), &[true], "{source}");
+        assert!(output.errors.is_empty(), "{source}");
+    }
+}

--- a/evaluator/tests/generated_contract.rs
+++ b/evaluator/tests/generated_contract.rs
@@ -54,6 +54,8 @@ fn generated_contract_is_deterministic_ordered_and_unique() {
     assert!(!first.contains("todo!"));
     assert!(!first.contains("unreachable!"));
     assert!(!first.contains("placeholder implementation"));
+    assert!(!first.contains("DynamicValueArgs"));
+    assert!(!first.contains("into_dynamic"));
     assert!(first.contains("fn eval<C: BuiltinValueContext>"));
     for line in first.lines().filter(|line| {
         line.starts_with("pub(crate) struct ")
@@ -206,13 +208,7 @@ struct BooleanKind;
 struct TextKind;
 struct DateKind;
 struct ListKind;
-struct Column;
-
 struct KernelColumn<K>(PhantomData<K>);
-
-impl<K> KernelColumn<K> {
-    fn into_column(self) -> Column { Column }
-}
 
 struct KernelResult<K>(PhantomData<K>);
 trait BuiltinValueContext {}
@@ -221,16 +217,6 @@ struct Mask;
 struct EvalBlock;
 struct DebugCallContract;
 struct PreparedArgumentError;
-
-struct DynamicValueArgs;
-
-impl DynamicValueArgs {
-    fn new(
-        _head: Vec<Option<Column>>,
-        _repeat: Vec<Vec<Option<Column>>>,
-        _tail: Vec<Option<Column>>,
-    ) -> Self { Self }
-}
 
 struct RepeatGroups<G>(Vec<G>);
 


### PR DESCRIPTION
## Summary

- execute all 83 supported builtin declarations through the synchronous prepared-input evaluator
- keep generated Args and Plans typed through handwritten Value and Controlled kernel boundaries
- implement lazy branch and lambda-list masks with runtime snapshot and row ID support
- add bounded public behavior coverage plus focused regressions found during semantic review
- update evaluator documentation, testing inventory, and changelog

## Architecture

The category catalog and generated dispatch ABI remain the compile-time source of obligations. Generated Value arguments flow directly into typed family kernels without DynamicValueArgs erasure. Controlled builtins retain typed plans and evaluate only selected row masks, preserving independent execution, validity, and row-error state.

## Verification

- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p evaluator --no-deps
- cargo test -p evaluator --release
- cargo run -p builtin_fn --bin builtin_catalog -- --check
- just docker-test
  - pnpm reported Already up to date and did not rebuild shared node_modules
  - 18 wasm tests, 50 frontend unit tests, and 26 Playwright E2E tests passed

Two-axis standards and spec review has no remaining actionable finding.

## Follow-up

After this PR merges, a separate cleanup PR will split the large Value family module, encapsulate Controlled predicate strategy, and share range decoding between substring and slice.